### PR TITLE
Make PostgreSQL version requirement explicit in Makefile and README

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,14 @@ PG_CONFIG = pg_config
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 
+ifndef MAJORVERSION
+    MAJORVERSION := $(basename $(VERSION))
+endif
+
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4))
+    $(error PostgreSQL 9.3 or 9.4 is required to compile this extension)
+endif
+
 cstore.pb-c.c: cstore.proto
 	protoc-c --c_out=. cstore.proto
 

--- a/README.md
+++ b/README.md
@@ -61,6 +61,9 @@ installation's bin/ directory path. For example:
     PATH=/usr/local/pgsql/bin/:$PATH make
     sudo PATH=/usr/local/pgsql/bin/:$PATH make install
 
+**Note.** cstore_fdw requires PostgreSQL 9.3 or 9.4. It doesn't support earlier
+versions of PostgreSQL.
+
 
 Usage
 -----


### PR DESCRIPTION
The "ifeq (...) $(error ...) endif" works in GNU Make 3.78+. Although, PostgreSQL 9.1+ require GNU Make 3.80+. GNU Make 3.78 was released in 1999 and 3.80 was released in 2002.

Also added a note to the README file which mentions that cstore_fdw supports only PostgreSQL 9.3 and 9.4.

Tested this with different GNU Make versions and PostgreSQL 8.4+.
