### PR TITLE
Fixed the deadlock issue for concurrent inserts.

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -391,10 +391,10 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 	Assert(copyStatement->relation != NULL);
 
 	/*
-	 * Open and lock the relation. We acquire ExclusiveLock to allow concurrent
-	 * reads, but block concurrent writes.
+	 * Open and lock the relation. We acquire ShareUpdateExclusiveLock to allow
+	 * concurrent reads, but block concurrent writes.
 	 */
-	relation = heap_openrv(copyStatement->relation, ExclusiveLock);
+	relation = heap_openrv(copyStatement->relation, ShareUpdateExclusiveLock);
 	relationId = RelationGetRelid(relation);
 
 	/* allocate column values and nulls arrays */
@@ -451,7 +451,7 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 	/* end read/write sessions and close the relation */
 	EndCopyFrom(copyState);
 	CStoreEndWrite(writeState);
-	heap_close(relation, ExclusiveLock);
+	heap_close(relation, ShareUpdateExclusiveLock);
 
 	return processedRowCount;
 }
@@ -1697,7 +1697,7 @@ CStoreBeginForeignModify(ModifyTableState *modifyTableState,
 	Assert (modifyTableState->operation == CMD_INSERT);
 
 	foreignTableOid = RelationGetRelid(relationInfo->ri_RelationDesc);
-	relation = heap_open(foreignTableOid, ExclusiveLock);
+	relation = heap_open(foreignTableOid, ShareUpdateExclusiveLock);
 	cstoreFdwOptions = CStoreGetOptions(foreignTableOid);
 	tupleDescriptor = RelationGetDescr(relationInfo->ri_RelationDesc);
 
@@ -1751,7 +1751,7 @@ CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo)
 		Relation relation = writeState->relation;
 
 		CStoreEndWrite(writeState);
-		heap_close(relation, ExclusiveLock);
+		heap_close(relation, ShareUpdateExclusiveLock);
 	}
 }
 


### PR DESCRIPTION
Previously we were using Exclusive locks to protect concurrent INSERTs from each other. But since PostgreSQL acquires RowExclusive locks automatically before executing cstore's insert logic, and Exclusive & RowExclusive locks conflict, this resulted in deadlock.

This pull request fixes this by using ShareUpdateExclusive locks, which is self-conflicting, but doesn't conflict with RowExclusive locks.
