### PR TITLE
PostgreSQL 9.5 support.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4))
-    $(error PostgreSQL 9.3 or 9.4 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5))
+    $(error PostgreSQL 9.3, 9.4 or 9.5 is required to compile this extension)
 endif
 
 cstore.pb-c.c: cstore.proto

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ MODULE_big = cstore_fdw
 
 PG_CPPFLAGS = --std=c99
 SHLIB_LINK = -lprotobuf-c
-OBJS = cstore.pb-c.o cstore_fdw.o cstore_writer.o cstore_reader.o \
+OBJS = cstore_utils.o cstore.pb-c.o cstore_fdw.o cstore_writer.o cstore_reader.o \
        cstore_metadata_serialization.o
 
 EXTENSION = cstore_fdw

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1175,9 +1175,16 @@ CStoreGetForeignPlan(PlannerInfo *root, RelOptInfo *baserel, Oid foreignTableId,
 	foreignPrivateList = list_make1(columnList);
 
 	/* create the foreign scan node */
-	foreignScan = make_foreignscan(targetList, scanClauses, baserel->relid,
-								   NIL, /* no expressions to evaluate */
-								   foreignPrivateList);
+	foreignScan = make_foreignscan(targetList,
+					scanClauses,
+					baserel->relid,
+					NIL, /* no expressions to evaluate */
+					foreignPrivateList
+#if PG_VERSION_NUM >= 90500
+					,NIL /* no custom tlist */
+					,NIL /* no remote expr */
+#endif
+					);
 
 	return foreignScan;
 }

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -57,6 +57,26 @@
 #define CSTORE_POSTSCRIPT_SIZE_LENGTH 1
 #define CSTORE_POSTSCRIPT_SIZE_MAX 256
 
+#if PG_VERSION_NUM >= 90500
+typedef struct PGLZ_Header
+{
+        int32           vl_len_;                /* varlena header (do not touch directly!) */
+        int32           rawsize;
+} PGLZ_Header;
+
+
+/* ----------
+ * PGLZ_RAW_SIZE -
+ *
+ *              Macro to determine the uncompressed data size contained
+ *              in the entry.
+ * ----------
+ */
+#define PGLZ_RAW_SIZE(_lzdata)                  ((_lzdata)->rawsize)
+#define PGLZ_SET_RAW_SIZE(_lzdata, l)           (_lzdata->rawsize = l)
+#endif
+
+
 
 /*
  * CStoreValidOption keeps an option name and a context. When an option is passed

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -57,26 +57,6 @@
 #define CSTORE_POSTSCRIPT_SIZE_LENGTH 1
 #define CSTORE_POSTSCRIPT_SIZE_MAX 256
 
-#if PG_VERSION_NUM >= 90500
-typedef struct PGLZ_Header
-{
-        int32           vl_len_;                /* varlena header (do not touch directly!) */
-        int32           rawsize;
-} PGLZ_Header;
-
-
-/* ----------
- * PGLZ_RAW_SIZE -
- *
- *              Macro to determine the uncompressed data size contained
- *              in the entry.
- * ----------
- */
-#define PGLZ_RAW_SIZE(_lzdata)                  ((_lzdata)->rawsize)
-#define PGLZ_SET_RAW_SIZE(_lzdata, l)           (_lzdata->rawsize = l)
-#endif
-
-
 
 /*
  * CStoreValidOption keeps an option name and a context. When an option is passed

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -30,7 +30,11 @@
 #include "storage/fd.h"
 #include "utils/memutils.h"
 #include "utils/lsyscache.h"
+#if PG_VERSION_NUM >= 90500
+#include "common/pg_lzcompress.h"
+#else
 #include "utils/pg_lzcompress.h"
+#endif
 #include "utils/rel.h"
 
 
@@ -1322,6 +1326,22 @@ ReadFromFile(FILE *file, uint64 offset, uint32 size)
 
 
 /*
+ * This is a wrapper function on PostgreSQL's pglz_decompress
+ * function, because PostgreSQL 9.5 changes the function prototype.
+ */
+static void
+pglz_cstore_decompress(const PGLZ_Header *source, char *dest)
+{
+#if PG_VERSION_NUM >= 90500
+	char *sp = (char*)((const unsigned char *) source) + sizeof(PGLZ_Header);
+	pglz_decompress (sp, VARSIZE(source), dest, PGLZ_RAW_SIZE(source));
+#else
+	pglz_decompress(source, dest);
+#endif
+}
+
+
+/*
  * DecompressBuffer decompresses the given buffer with the given compression
  * type. This function returns the buffer as-is when no compression is applied.
  */
@@ -1352,8 +1372,7 @@ DecompressBuffer(StringInfo buffer, CompressionType compressionType)
 		}
 
 		decompressedData = palloc0(decompressedDataSize);
-		pglz_decompress(compressedData, decompressedData);
-
+        pglz_cstore_decompress(compressedData, decompressedData);
 		decompressedBuffer = palloc0(sizeof(StringInfoData));
 		decompressedBuffer->data = decompressedData;
 		decompressedBuffer->len = decompressedDataSize;

--- a/cstore_utils.c
+++ b/cstore_utils.c
@@ -1,0 +1,59 @@
+/*-------------------------------------------------------------------------
+ *
+ * cstore_utils.c
+ *
+ * This file contains utility functions definitions for cstore
+ *
+ * Copyright (c) 2015, Citus Data, Inc.
+ *
+ * $Id$
+ *
+ *-------------------------------------------------------------------------
+ */
+
+
+#include "postgres.h"
+#include "cstore_fdw.h"
+#include "cstore_utils.h"
+
+
+/*
+ * This is a wrapper function on PostgreSQL's pglz_compress
+ * function, because PostgreSQL 9.5 changes the function signature.
+ */
+bool
+cstore_pglz_compress(const char *source, int32 slen, PGLZ_Header *dest,
+                          const PGLZ_Strategy *strategy)
+{
+#if PG_VERSION_NUM >= 90500
+	StringInfoData *info = (StringInfoData*)dest;
+	int	compressedLength = 0;
+	char *bp = (char*)((unsigned char *) info) + sizeof(PGLZ_Header);
+
+	compressedLength = pglz_compress(source, slen, bp, strategy);
+	if (compressedLength <= 0)
+		return false;
+
+	dest->rawsize = slen;
+	SET_VARSIZE_COMPRESSED(dest, compressedLength + sizeof(PGLZ_Header));
+#else
+	return pglz_compress(source, slen, dest, strategy);
+#endif
+	return true;
+}
+
+
+/*
+ * This is a wrapper function on PostgreSQL's pglz_decompress
+ * function, because PostgreSQL 9.5 changes the function prototype.
+ */
+void
+cstore_pglz_decompress(const PGLZ_Header *source, char *dest)
+{
+#if PG_VERSION_NUM >= 90500
+	char *sp = (char*)((const unsigned char *) source) + sizeof(PGLZ_Header);
+	pglz_decompress (sp, VARSIZE(source), dest, PGLZ_RAW_SIZE(source));
+#else
+	pglz_decompress(source, dest);
+#endif
+}

--- a/cstore_utils.h
+++ b/cstore_utils.h
@@ -1,0 +1,44 @@
+/*-------------------------------------------------------------------------
+ *
+ * cstore_utils.h
+ *
+ * Type and function declarations for CStore utility functions.
+ *
+ * Copyright (c) 2015, Citus Data, Inc.
+ *
+ * $Id$
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CSTORE_UTILS_H
+#define CSTORE_UTILS_H
+
+#if PG_VERSION_NUM >= 90500
+#include "common/pg_lzcompress.h"
+#else
+#include "utils/pg_lzcompress.h"
+#endif
+
+#if PG_VERSION_NUM >= 90500
+typedef struct PGLZ_Header
+{
+        int32           vl_len_;                /* varlena header (do not touch directly!) */
+        int32           rawsize;
+} PGLZ_Header;
+
+
+/* ----------
+ * PGLZ_RAW_SIZE -
+ *
+ *              Macro to determine the uncompressed data size contained
+ *              in the entry.
+ * ----------
+ */
+#define PGLZ_RAW_SIZE(_lzdata)                  ((_lzdata)->rawsize)
+#define PGLZ_SET_RAW_SIZE(_lzdata, l)           (_lzdata->rawsize = l)
+#endif
+
+bool cstore_pglz_compress(const char *source, int32 slen, PGLZ_Header *dest, const PGLZ_Strategy *strategy);
+void cstore_pglz_decompress(const PGLZ_Header *source, char *dest);
+#endif   /* CSTORE_UTILS_H */

--- a/cstore_writer.c
+++ b/cstore_writer.c
@@ -27,14 +27,8 @@
 #include "storage/fd.h"
 #include "utils/memutils.h"
 #include "utils/lsyscache.h"
-#if PG_VERSION_NUM >= 90500
-#include "common/pg_lzcompress.h"
-#else
-#include "utils/pg_lzcompress.h"
-#endif
-
 #include "utils/rel.h"
-
+#include "cstore_utils.h"
 
 static void CStoreWriteFooter(StringInfo footerFileName, TableFooter *tableFooter);
 static StripeBuffers * CreateEmptyStripeBuffers(uint32 stripeMaxRowCount,
@@ -773,31 +767,6 @@ SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
 
 
 /*
- * This is a wrapper function on PostgreSQL's pglz_compress
- * function, because PostgreSQL 9.5 changes the function signature.
- */
-static bool
-pglz_cstore_compress(const char *source, int32 slen, PGLZ_Header *dest,
-                          const PGLZ_Strategy *strategy)
-{
-#if PG_VERSION_NUM >= 90500
-	StringInfoData *info = (StringInfoData*)dest;
-	int	compressedLength = 0;
-	char *bp = (char*)((unsigned char *) info) + sizeof(PGLZ_Header);
-
-	compressedLength = pglz_compress(source, slen, bp, strategy);
-	if (compressedLength <= 0)
-		return false;
-
-	dest->rawsize = slen;
-	SET_VARSIZE_COMPRESSED(dest, compressedLength + sizeof(PGLZ_Header));
-#else
-	return pglz_compress(source, slen, dest, strategy);
-#endif
-	return true;
-}
-
-/*
  * SerializeBlockData serializes and compresses block data at given block index with given
  * compression type for every column.
  */
@@ -825,7 +794,6 @@ SerializeBlockData(TableWriteState *writeState, uint32 blockIndex, uint32 rowCou
 	 * check and compress value buffers, if a value buffer is not compressable
 	 * then keep it as uncompressed, store compression information.
 	 */
-
 	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		uint64 maximumLength = 0;
@@ -853,10 +821,11 @@ SerializeBlockData(TableWriteState *writeState, uint32 blockIndex, uint32 rowCou
 			resetStringInfo(compressionBuffer);
 			enlargeStringInfo(compressionBuffer, maximumLength);
 
-			compressable = pglz_cstore_compress((const char *) serializedValueBuffer->data,
+			compressable = cstore_pglz_compress((const char *) serializedValueBuffer->data,
 										  serializedValueBuffer->len,
 										  (PGLZ_Header*)compressionBuffer->data,
 										  PGLZ_strategy_always);
+
 			if (compressable)
 			{
 				serializedValueBuffer = compressionBuffer;


### PR DESCRIPTION
Signature of PostgreSQL' pglz_compress and pglz_decompress
change in PostgreSQL version 9.5. This commit introduces
new functions pglz_cstore_compress and pglz_cstore_decompress
to accomodate 9.5 changes.