### PR TITLE
Fix copy with transmit option when used in Citus

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -304,7 +304,7 @@ CopyCStoreTableStatement(CopyStmt* copyStatement)
 	if (copyStatement->relation != NULL)
 	{
 		Oid relationId = RangeVarGetRelid(copyStatement->relation,
-										  AccessShareLock, false);
+										  AccessShareLock, true);
 		copyCStoreTableStatement = CStoreTable(relationId);
 	}
 


### PR DESCRIPTION
cstore_fdw tries to determine if given table is infact a cstore table during copy operation. However,  if given name is not a table at all, cstore fails at this stage and stops copy processing altogether. 

This change  enables cstore_fdw to determine whether a given name is a cstore_fdw table without affecting the rest of copy handling.  If an error is encountered, cstore_fdw stops its own handling only instead of stopping the whole copy operation. 
