### PR TITLE
Let Citus handle COPY on distributed cstore_fdw tables

### DIFF
--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -57,6 +57,14 @@
 #define CSTORE_POSTSCRIPT_SIZE_LENGTH 1
 #define CSTORE_POSTSCRIPT_SIZE_MAX 256
 
+/* table containing information about how to partition distributed tables */
+#define CITUS_EXTENSION_NAME "citus"
+#define CITUS_PARTITION_TABLE_NAME "pg_dist_partition"
+
+/* human-readable names for addressing columns of the pg_dist_partition table */
+#define ATTR_NUM_PARTITION_RELATION_ID 1
+#define ATTR_NUM_PARTITION_TYPE 2
+#define ATTR_NUM_PARTITION_KEY 3
 
 
 /*


### PR DESCRIPTION
With the new COPY for distributed tables in Citus, we need a way to skip cstore_fdw's COPY implementation for distributed columnar tables. Since citus always needs to come first in shared_preload_libraries, cstore_fdw's ProcessUtility hook always overrides citus' ProcessUtility hook and thus comes first.

After this change, when issuing a COPY command on a columnar table, cstore_fdw first checks whether the Citus extension is loaded, the pg_dist_partition table exists, and  pg_dist_partition contains a record for the cstore_fdw table. If so it lets the COPY fall through to citus.