### PR TITLE
Reduce function calls to var's during requested column computation

### DIFF
--- a/expected/query.out
+++ b/expected/query.out
@@ -82,3 +82,24 @@ SELECT to_json(v) FROM contestant v ORDER BY rating LIMIT 1;
  {"handle":"g","birthdate":"1991-12-13","rating":1803,"percentile":85.1,"country":"XD ","achievements":["a","c"]}
 (1 row)
 
+-- Test variables used in expressions
+CREATE FOREIGN TABLE union_first (a int, b int) SERVER cstore_server;
+CREATE FOREIGN TABLE union_second (a int, b int) SERVER cstore_server;
+INSERT INTO union_first SELECT a, a FROM generate_series(1, 5) a;
+INSERT INTO union_second SELECT a, a FROM generate_series(11, 15) a;
+(SELECT a*1, b FROM union_first) union all (SELECT a*1, b FROM union_second);
+ ?column? | b  
+----------+----
+        1 |  1
+        2 |  2
+        3 |  3
+        4 |  4
+        5 |  5
+       11 | 11
+       12 | 12
+       13 | 13
+       14 | 14
+       15 | 15
+(10 rows)
+
+DROP FOREIGN TABLE union_first, union_second;

--- a/sql/query.sql
+++ b/sql/query.sql
@@ -21,3 +21,14 @@ SELECT * FROM contestant_compressed ORDER BY handle;
 
 -- Verify that we handle whole-row references correctly
 SELECT to_json(v) FROM contestant v ORDER BY rating LIMIT 1;
+
+-- Test variables used in expressions
+CREATE FOREIGN TABLE union_first (a int, b int) SERVER cstore_server;
+CREATE FOREIGN TABLE union_second (a int, b int) SERVER cstore_server;
+
+INSERT INTO union_first SELECT a, a FROM generate_series(1, 5) a;
+INSERT INTO union_second SELECT a, a FROM generate_series(11, 15) a;
+
+(SELECT a*1, b FROM union_first) union all (SELECT a*1, b FROM union_second);
+
+DROP FOREIGN TABLE union_first, union_second;


### PR DESCRIPTION
Postgresql does not reduce some function calls in target list when used in ```union all``` queries. This change uses ```pull_var_clause()``` to detect Var's used in target list when detecting which columns should be returned for the query on cstore table.

Fixes #107 and #95 
