### PR TITLE
Add alter column type verifications to prevent incorrect changes

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -44,6 +44,8 @@
 #include "optimizer/var.h"
 #include "parser/parser.h"
 #include "parser/parsetree.h"
+#include "parser/parse_coerce.h"
+#include "parser/parse_type.h"
 #include "tcop/utility.h"
 #include "utils/builtins.h"
 #include "utils/fmgroids.h"
@@ -69,6 +71,7 @@ static void CStoreProcessCopyCommand(CopyStmt *copyStatement, const char *queryS
 static uint64 CopyIntoCStoreTable(const CopyStmt *copyStatement,
 								  const char *queryString);
 static uint64 CopyOutCStoreTable(CopyStmt* copyStatement, const char* queryString);
+static void CStoreProcessAlterTableCommand(AlterTableStmt *alterStatement);
 static List * DroppedCStoreFilenameList(DropStmt *dropStatement);
 static List * FindCStoreTables(List *tableList);
 static void TruncateCStoreTables(List *cstoreTableList);
@@ -265,6 +268,13 @@ CStoreProcessUtility(Node *parseTree, const char *queryString,
 		}
 
 		TruncateCStoreTables(cstoreTablesList);
+	}
+	else if (nodeTag(parseTree) == T_AlterTableStmt)
+	{
+		AlterTableStmt *alterTable = (AlterTableStmt *) parseTree;
+		CStoreProcessAlterTableCommand(alterTable);
+		CallPreviousProcessUtility(parseTree, queryString, context,
+								   paramListInfo, destReceiver, completionTag);
 	}
 	/* handle other utility statements */
 	else
@@ -527,6 +537,68 @@ CopyOutCStoreTable(CopyStmt* copyStatement, const char* queryString)
 	DoCopy(copyStatement, queryString, &processedCount);
 
 	return processedCount;
+}
+
+
+/*
+ * CStoreProcessAlterTableCommand checks if given alter table statement is
+ * compatible with underlying data structure. Currently it only checks alter
+ * column type. The function errors out if current column type can not be safely
+ * converted to requested column type. This check is more restrictive than
+ * PostgreSQL's because we can not change existing data.
+ */
+static void
+CStoreProcessAlterTableCommand(AlterTableStmt *alterStatement)
+{
+	ObjectType objectType = alterStatement->relkind;
+	RangeVar *relationRangeVar = alterStatement->relation;
+	Oid relationId = InvalidOid;
+	List *commandList = alterStatement->cmds;
+	ListCell *commandCell = NULL;
+
+	/* we are only interested in foreign table changes */
+	if (objectType != OBJECT_TABLE && objectType != OBJECT_FOREIGN_TABLE)
+	{
+		return;
+	}
+
+	relationId = RangeVarGetRelid(relationRangeVar, AccessShareLock, true);
+	if (!CStoreTable(relationId))
+	{
+		return;
+	}
+
+	foreach(commandCell, commandList)
+	{
+		AlterTableCmd *alterCommand = (AlterTableCmd *) lfirst(commandCell);
+		if(alterCommand->subtype == AT_AlterColumnType)
+		{
+			char *columnName = alterCommand->name;
+			ColumnDef *columnDef = (ColumnDef *) alterCommand->def;
+			Oid targetTypeId = typenameTypeId(NULL, columnDef->typeName);;
+			char *typeName = TypeNameToString(columnDef->typeName);
+			AttrNumber attributeNumber = get_attnum(relationId, columnName);
+			Oid currentTypeId = InvalidOid;
+
+			if (attributeNumber <= 0)
+			{
+				/* let standard utility handle this */
+				continue;
+			}
+
+			currentTypeId = get_atttype(relationId, attributeNumber);
+
+			/*
+			 * We are only interested in implicit coersion type compatibility.
+			 * Erroring out here to prevent further processing.
+			 */
+			if (!can_coerce_type(1, &currentTypeId, &targetTypeId, COERCION_IMPLICIT))
+			{
+				ereport(ERROR, (errmsg("Column %s cannot be cast automatically to "
+									   "type %s", columnName, typeName)));
+			}
+		}
+	}
 }
 
 

--- a/expected/alter.out
+++ b/expected/alter.out
@@ -151,4 +151,16 @@ SELECT * FROM test_alter_table;
  1 | 4 | ABCDEF  |   | 
 (7 rows)
 
+-- unsupported type change
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN i int;
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN j float;
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN k text;
+-- this is valid type change
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN i TYPE float;
+-- this is not valid
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN j TYPE int;
+ERROR:  Column j cannot be cast automatically to type pg_catalog.int4
+-- text / varchar conversion is valid both ways
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN k TYPE varchar(20);
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN k TYPE text;
 DROP FOREIGN TABLE test_alter_table;

--- a/sql/alter.sql
+++ b/sql/alter.sql
@@ -65,4 +65,19 @@ ALTER FOREIGN TABLE test_alter_table ALTER COLUMN h DROP DEFAULT;
 ANALYZE test_alter_table;
 SELECT * FROM test_alter_table;
 
+-- unsupported type change
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN i int;
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN j float;
+ALTER FOREIGN TABLE test_alter_table ADD COLUMN k text;
+
+-- this is valid type change
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN i TYPE float;
+
+-- this is not valid
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN j TYPE int;
+
+-- text / varchar conversion is valid both ways
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN k TYPE varchar(20);
+ALTER FOREIGN TABLE test_alter_table ALTER COLUMN k TYPE text;
+
 DROP FOREIGN TABLE test_alter_table;


### PR DESCRIPTION
We relied on PostgreSQL to to type checking and did not verify anything at extension level.
This has caused some usability issues when column type is altered to incompatible type.
We now perform compatibility check for alter table statement before letting standard utility to handle the command.

Fixes #71 