### PR TITLE
Adding instructions to install libprotoc-dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ So we need to install these packages first:
     # Ubuntu 10.4+
     sudo apt-get install protobuf-c-compiler
     sudo apt-get install libprotobuf-c0-dev
+    sudo apt-get install libprotoc-dev
 
     # Mac OS X
     brew install protobuf-c


### PR DESCRIPTION
I have faced compilation errors due to a missing dependency when building the `cstore_fdw` extension. Installing the `libprotoc-dev` dependency has solved the issue in my case.

I am submitting this pull request with an update to the documentation (i.e. README.md), instructing users to install that library also via:

```
sudo apt-get install libprotoc-dev
```

Fixes #130