### PR TITLE
adds snappy and defate (zlib) compression

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,8 +43,15 @@
 /data/*.footer
 
 /sql/block_filtering.sql
+/sql/copyto.sql
 /sql/create.sql
 /sql/data_types.sql
 /sql/load.sql
+
+/expected/block_filtering.out
+/expected/copyto.out
+/expected/create.out
+/expected/data_types.out
+/expected/load.out
 
 *.pb-c.*

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 before_install:
   - sudo apt-get update -qq
   - sudo update-alternatives --remove-all postmaster.1.gz
-  - git clone -b v0.5.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.1 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - nuke_pg
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,8 +15,9 @@ env:
     - PGVERSION=9.5
     - PGVERSION=9.6
     - PGVERSION=10
+    - PGVERSION=11
 before_install:
-  - git clone -b v0.6.3 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.9 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - nuke_pg

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
+sudo: required
+dist: trusty
 language: c
-cache: apt
+cache:
+  apt: true
+  directories:
+    - /home/travis/postgresql
 env:
   global:
     - enable_coverage=yes
@@ -9,11 +14,11 @@ env:
     - PGVERSION=9.4
     - PGVERSION=9.5
     - PGVERSION=9.6
+    - PGVERSION=10
 before_install:
-  - sudo apt-get update -qq
-  - sudo update-alternatives --remove-all postmaster.1.gz
-  - git clone -b v0.6.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.3 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
+  - setup_apt
   - nuke_pg
 install:
   - sudo apt-get install libsnappy-dev zlib1g-dev
@@ -23,6 +28,7 @@ install:
   - sudo locale-gen da_DK.utf8
   - sudo pip install cpp-coveralls
   - install_pg
+  - install_custom_pg
 before_script:
   - chmod 777 .
   - chmod 777 data

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,11 +8,13 @@ env:
     - PGVERSION=9.3
     - PGVERSION=9.4
     - PGVERSION=9.5
+    - PGVERSION=9.6
 before_install:
   - sudo apt-get update -qq
   - sudo update-alternatives --remove-all postmaster.1.gz
-  - git clone -b v0.3.3 --depth 1 https://github.com/citusdata/tools.git
-  - tools/travis/nuke_pg.sh
+  - git clone -b v0.5.1 --depth 1 https://github.com/citusdata/tools.git
+  - sudo make -C tools install
+  - nuke_pg
 install:
   - sudo apt-get install libsnappy-dev zlib1g-dev
   - sudo apt-get install protobuf-c-compiler
@@ -20,13 +22,13 @@ install:
   - sudo locale-gen da_DK
   - sudo locale-gen da_DK.utf8
   - sudo pip install cpp-coveralls
-  - tools/travis/install_pg.sh
+  - install_pg
 before_script:
   - chmod 777 .
   - chmod 777 data
   - chmod 666 data/*
-  - tools/travis/config_and_start_cluster.sh
-script: tools/travis/pg_travis_test.sh
+  - config_and_start_cluster
+script: pg_travis_test
 after_success:
   - sudo chmod 666 *.gcda
   - coveralls --exclude cstore.pb-c.c --exclude cstore.pb-c.h

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,10 @@ env:
     - PGVERSION=9.6
     - PGVERSION=10
     - PGVERSION=11
+    - PGVERSION=12
+
 before_install:
-  - git clone -b v0.7.9 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.7.13 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - setup_apt
   - nuke_pg

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
 install:
   - sudo apt-get install libsnappy-dev zlib1g-dev
   - sudo apt-get install protobuf-c-compiler
-  - sudo apt-get install libprotobuf-c0-dev
   - sudo locale-gen da_DK
   - sudo locale-gen da_DK.utf8
   - sudo pip install cpp-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 sudo: required
-dist: trusty
+dist: bionic
 language: c
 cache:
   apt: true
@@ -26,6 +26,7 @@ before_install:
 install:
   - sudo apt-get install libsnappy-dev zlib1g-dev
   - sudo apt-get install protobuf-c-compiler
+  - sudo apt-get install libprotobuf-c0-dev
   - sudo locale-gen da_DK
   - sudo locale-gen da_DK.utf8
   - sudo pip install cpp-coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ before_install:
   - git clone -b v0.3.3 --depth 1 https://github.com/citusdata/tools.git
   - tools/travis/nuke_pg.sh
 install:
+  - sudo apt-get install libsnappy-dev zlib1g-dev
   - sudo apt-get install protobuf-c-compiler
   - sudo apt-get install libprotobuf-c0-dev
   - sudo locale-gen da_DK

--- a/META.json
+++ b/META.json
@@ -10,7 +10,7 @@
          "abstract": "Foreign Data Wrapper for Columnar Store Tables",
          "file": "cstore_fdw--1.7.sql",
          "docfile": "README.md",
-         "version": "1.6.2"
+         "version": "1.7.0"
       }
    },
    "prereqs": {

--- a/META.json
+++ b/META.json
@@ -2,13 +2,13 @@
    "name": "cstore_fdw",
    "abstract": "Columnar Store for PostgreSQL",
    "description": "PostgreSQL extension which implements a Columnar Store.",
-   "version": "1.6.2",
-   "maintainer": "Murat Tuncer <mtuncer@citusdata.com>",
+   "version": "1.7.0",
+   "maintainer": "Murat Tuncer <murat.tuncer@microsoft.com>",
    "license": "apache_2_0",
    "provides": {
       "cstore_fdw": {
          "abstract": "Foreign Data Wrapper for Columnar Store Tables",
-         "file": "cstore_fdw--1.6.sql",
+         "file": "cstore_fdw--1.7.sql",
          "docfile": "README.md",
          "version": "1.6.2"
       }

--- a/META.json
+++ b/META.json
@@ -2,7 +2,7 @@
    "name": "cstore_fdw",
    "abstract": "Columnar Store for PostgreSQL",
    "description": "PostgreSQL extension which implements a Columnar Store.",
-   "version": "1.6.0",
+   "version": "1.6.2",
    "maintainer": "Murat Tuncer <mtuncer@citusdata.com>",
    "license": "apache_2_0",
    "provides": {
@@ -10,7 +10,7 @@
          "abstract": "Foreign Data Wrapper for Columnar Store Tables",
          "file": "cstore_fdw--1.6.sql",
          "docfile": "README.md",
-         "version": "1.6.0"
+         "version": "1.6.2"
       }
    },
    "prereqs": {

--- a/META.json
+++ b/META.json
@@ -2,15 +2,15 @@
    "name": "cstore_fdw",
    "abstract": "Columnar Store for PostgreSQL",
    "description": "PostgreSQL extension which implements a Columnar Store.",
-   "version": "1.5.0",
+   "version": "1.6.0",
    "maintainer": "Murat Tuncer <mtuncer@citusdata.com>",
    "license": "apache_2_0",
    "provides": {
       "cstore_fdw": {
          "abstract": "Foreign Data Wrapper for Columnar Store Tables",
-         "file": "cstore_fdw--1.5.sql",
+         "file": "cstore_fdw--1.6.sql",
          "docfile": "README.md",
-         "version": "1.5.0"
+         "version": "1.6.0"
       }
    },
    "prereqs": {

--- a/Makefile
+++ b/Makefile
@@ -41,8 +41,8 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
-    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 or 10 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10 11))
+    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 or 10 or 11 is required to compile this extension)
 endif
 
 cstore.pb-c.c: cstore.proto

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6))
-    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
+    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 or 10 is required to compile this extension)
 endif
 
 cstore.pb-c.c: cstore.proto

--- a/Makefile
+++ b/Makefile
@@ -46,8 +46,8 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10 11))
-    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 or 10 or 11 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10 11 12))
+    $(error PostgreSQL 9.3 to 12 is required to compile this extension)
 endif
 
 cstore.pb-c.c: cstore.proto

--- a/Makefile
+++ b/Makefile
@@ -28,6 +28,11 @@ ifeq ($(enable_coverage),yes)
 	EXTRA_CLEAN += *.gcno
 endif
 
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	PG_CPPFLAGS += -I/usr/local/include
+endif
+
 #
 # Users need to specify their Postgres installation path through pg_config. For
 # example: /usr/local/pgsql/bin/pg_config or /usr/lib/postgresql/9.3/bin/pg_config

--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ OBJS = cstore.pb-c.o cstore_fdw.o cstore_writer.o cstore_reader.o \
        cstore_metadata_serialization.o cstore_compression.o
 
 EXTENSION = cstore_fdw
-DATA = cstore_fdw--1.6.sql cstore_fdw--1.5--1.6.sql cstore_fdw--1.4--1.5.sql \
+DATA = cstore_fdw--1.7.sql cstore_fdw--1.6--1.7.sql  cstore_fdw--1.5--1.6.sql cstore_fdw--1.4--1.5.sql \
 	   cstore_fdw--1.3--1.4.sql cstore_fdw--1.2--1.3.sql cstore_fdw--1.1--1.2.sql \
 	   cstore_fdw--1.0--1.1.sql
 

--- a/Makefile
+++ b/Makefile
@@ -5,8 +5,8 @@
 
 MODULE_big = cstore_fdw
 
-PG_CPPFLAGS = --std=c99
-SHLIB_LINK = -lprotobuf-c
+PG_CPPFLAGS = --std=c99 -O2
+SHLIB_LINK = -lprotobuf-c -lsnappy -lz
 OBJS = cstore.pb-c.o cstore_fdw.o cstore_writer.o cstore_reader.o \
        cstore_metadata_serialization.o cstore_compression.o
 

--- a/Makefile
+++ b/Makefile
@@ -11,8 +11,9 @@ OBJS = cstore.pb-c.o cstore_fdw.o cstore_writer.o cstore_reader.o \
        cstore_metadata_serialization.o cstore_compression.o
 
 EXTENSION = cstore_fdw
-DATA = cstore_fdw--1.5.sql cstore_fdw--1.4--1.5.sql cstore_fdw--1.3--1.4.sql \
-	   cstore_fdw--1.2--1.3.sql cstore_fdw--1.1--1.2.sql cstore_fdw--1.0--1.1.sql
+DATA = cstore_fdw--1.6.sql cstore_fdw--1.5--1.6.sql cstore_fdw--1.4--1.5.sql \
+	   cstore_fdw--1.3--1.4.sql cstore_fdw--1.2--1.3.sql cstore_fdw--1.1--1.2.sql \
+	   cstore_fdw--1.0--1.1.sql
 
 REGRESS = create load query analyze data_types functions block_filtering drop \
 		  insert copyto alter truncate

--- a/README.md
+++ b/README.md
@@ -285,6 +285,9 @@ the installation:
 
 Changeset
 ---------
+### Version 1.6.1
+* (Fix) Fix crash during truncate (Cstore crashing server when enabled, not used)
+* (Fix) No such file or directory warning when attempting to drop database
 ### Version 1.6
 * (Feature) Added support for PostgreSQL 10.
 * (Fix) Removed table files when a schema, extension or database is dropped.

--- a/README.md
+++ b/README.md
@@ -52,8 +52,7 @@ So we need to install these packages first:
     brew install protobuf-c
 
 **Note.** In CentOS 5, 6, and 7, you may need to install or update EPEL 5, 6, or 7 repositories.
- See [this page]
-(https://support.rackspace.com/how-to/install-epel-and-additional-repositories-on-centos-and-red-hat/)
+ See [this page](https://support.rackspace.com/how-to/install-epel-and-additional-repositories-on-centos-and-red-hat/)
 for instructions.
 
 **Note.** In Amazon Linux, the EPEL repository is installed by default, but not

--- a/README.md
+++ b/README.md
@@ -284,6 +284,8 @@ the installation:
 
 Changeset
 ---------
+### Version 1.6.2
+* (Fix) Add support for PostgreSQL 11
 ### Version 1.6.1
 * (Fix) Fix crash during truncate (Cstore crashing server when enabled, not used)
 * (Fix) No such file or directory warning when attempting to drop database

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ most efficient execution plan for each query.
 commands. We also don't support single row inserts.
 
 
-Updating from earlier versions to 1.6
+Updating from earlier versions to 1.7
 ---------------------------------------
 
 To update an existing cstore_fdw installation from versions earlier than 1.6
@@ -288,6 +288,12 @@ the installation:
 
 Changeset
 ---------
+### Version 1.7.0
+* (Fix) Add support for PostgreSQL 12
+* (Fix) Support count(t.*) from t type queries
+* (Fix) Build failures for MacOS 10.14+
+* (Fix) Make foreign scan parallel safe
+* (Fix) Add support for PostgreSQL 11 COPY
 ### Version 1.6.2
 * (Fix) Add support for PostgreSQL 11
 ### Version 1.6.1

--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ Join the [Mailing List][mailing-list] to stay on top of the latest developments 
 Introduction
 ------------
 
-This extension uses the Optimized Row Columnar (ORC) format for its data layout.
-ORC improves upon the RCFile format developed at Facebook, and brings the
-following benefits:
+This extension uses a format for its data layout that is inspired by ORC,
+the Optimized Row Columnar format. Like ORC, the cstore format improves
+upon RCFile developed at Facebook, and brings the following benefits:
 
 * Compression: Reduces in-memory and on-disk data size by 2-4x. Can be extended
   to support different codecs.

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ cstore_fdw
 
 Cstore_fdw is an open source columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytics use cases where data is loaded in batches. Cstore_fdw’s columnar nature delivers performance by only reading relevant data from disk, and it may compress data 6x-10x to reduce space requirements for data archival.
 
-Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus Data, our mission is to make it so you never have to worry about scaling your database again. So we built the Citus extension to Postgres, an extension that intelligently distributes your data and queries across many nodes so your database can scale and your queries are fast. The Citus extension to Postgres is available as open source, as on-prem enterprise software, and as a [fully-managed database as a service](https://www.citusdata.com/product/cloud). If you have any questions about how Citus can help you scale, [please let us know](https://www.citusdata.com/about/contact_us/).
+Cstore_fdw is developed by [Citus Data](https://www.citusdata.com) and can be used in combination with [Citus](https://github.com/citusdata/citus), a postgres extension that intelligently distributes your data and queries across many nodes so your database can scale and your queries are fast. If you have any questions about how Citus can help you scale or how to use Citus in combination with cstore_fdw, [please let us know](https://www.citusdata.com/about/contact_us/).
 
 Join the [Mailing List][mailing-list] to stay on top of the latest developments for Cstore_fdw.
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ So we need to install these packages first:
 
     # Ubuntu 10.4+
     sudo apt-get install protobuf-c-compiler
-    sudo apt-get install libprotobuf-c0-dev
 
     # Mac OS X
     brew install protobuf-c

--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ So we need to install these packages first:
 
     # Ubuntu 10.4+
     sudo apt-get install protobuf-c-compiler
+    sudo apt-get install libprotobuf-c0-dev
+    
+    # Ubuntu 18.4+
+    sudo apt-get install protobuf-c-compiler
+    sudo apt-get install libprotobuf-c-dev
 
     # Mac OS X
     brew install protobuf-c

--- a/README.md
+++ b/README.md
@@ -4,11 +4,11 @@ cstore_fdw
 [![Build Status](https://travis-ci.org/citusdata/cstore_fdw.svg?branch=master)][status]
 [![Coverage](http://img.shields.io/coveralls/citusdata/cstore_fdw/master.svg)][coverage]
 
-Cstore is a columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytic use cases where data is loaded in batches.
+Cstore_fdw is an open source columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytics use cases where data is loaded in batches. Cstore_fdw’s columnar nature delivers performance by only reading relevant data from disk, and it may compress data 6x-10x to reduce space requirements for data archival.
 
-Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus Data, our mission is to make it so you never have to worry about scaling your database again. So we built an extension to Postgres that intelligently distributes your data and queries across many nodes so your database can scale and your queries are fast. The Citus extension to Postgres is available as open source, as on-prem enterprise software, and as a fully-managed database as a service. If you have any questions about how Citus can help you scale please [let us know](https://www.citusdata.com/about/contact_us/).
+Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus Data, our mission is to make it so you never have to worry about scaling your database again. So we built the Citus extension to Postgres, an extension that intelligently distributes your data and queries across many nodes so your database can scale and your queries are fast. The Citus extension to Postgres is available as open source, as on-prem enterprise software, and as a [fully-managed database as a service](https://www.citusdata.com/product/cloud). If you have any questions about how Citus can help you scale, [please let us know](https://www.citusdata.com/about/contact_us/).
 
-Join the [Mailing List][mailing-list] to stay on top of the latest developments for Cstore.
+Join the [Mailing List][mailing-list] to stay on top of the latest developments for Cstore_fdw.
 
 
 Introduction

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ installation's bin/ directory path. For example:
     PATH=/usr/local/pgsql/bin/:$PATH make
     sudo PATH=/usr/local/pgsql/bin/:$PATH make install
 
-**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5, 9.6, 10 or 11. It doesn't
+**Note.** cstore_fdw requires PostgreSQL version from 9.3 to 12. It doesn't
 support earlier versions of PostgreSQL.
 
 
@@ -177,8 +177,8 @@ OPTIONS(compression 'pglz');
 Next, we load data into the table:
 
 ```SQL
-COPY customer_reviews FROM '/home/user/customer_reviews_1998.csv' WITH CSV;
-COPY customer_reviews FROM '/home/user/customer_reviews_1999.csv' WITH CSV;
+\COPY customer_reviews FROM 'customer_reviews_1998.csv' WITH CSV;
+\COPY customer_reviews FROM 'customer_reviews_1999.csv' WITH CSV;
 ```
 
 **Note.** If you are getting ```ERROR: cannot copy to foreign table
@@ -234,7 +234,7 @@ hosts.  You can easily install and run other PostgreSQL extensions and foreign d
 wrappers—including cstore_fdw—alongside Citus.
 
 You can create a cstore_fdw table and distribute it using the
-```master_create_distributed_table()``` UDF just like any other table. You can load data
+```create_distributed_table()``` UDF just like any other table. You can load data
 using the ```copy``` command as you would do in single node PostgreSQL.
 
 Using Skip Indexes

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ installation's bin/ directory path. For example:
     PATH=/usr/local/pgsql/bin/:$PATH make
     sudo PATH=/usr/local/pgsql/bin/:$PATH make install
 
-**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10. It doesn't
+**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5, 9.6, 10 or 11. It doesn't
 support earlier versions of PostgreSQL.
 
 

--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@ cstore_fdw
 [![Build Status](https://travis-ci.org/citusdata/cstore_fdw.svg?branch=master)][status]
 [![Coverage](http://img.shields.io/coveralls/citusdata/cstore_fdw/master.svg)][coverage]
 
-Cstore is a columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytic use-cases where data is loaded in batches.
+Cstore is a columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytic use cases where data is loaded in batches.
 
-Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus, our mission is to make it so you never have to worry about scaling again. We do this by allowing you to seamlessly scale out your Postgres database. The Citus extension is available as open source, an enterprise version, and a fully managed database as a service. If you have any questions about how Citus can help you scale please [let us know](https://www.citusdata.com/about/contact_us/).
+Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus Data, our mission is to make it so you never have to worry about scaling your database again. So we built an extension to Postgres that intelligently distributes your data and queries across many nodes so your database can scale and your queries are fast. The Citus extension to Postgres is available as open source, as on-prem enterprise software, and as a fully-managed database as a service. If you have any questions about how Citus can help you scale please [let us know](https://www.citusdata.com/about/contact_us/).
 
 Join the [Mailing List][mailing-list] to stay on top of the latest developments for Cstore.
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,11 @@ cstore_fdw
 [![Build Status](https://travis-ci.org/citusdata/cstore_fdw.svg?branch=master)][status]
 [![Coverage](http://img.shields.io/coveralls/citusdata/cstore_fdw/master.svg)][coverage]
 
-This extension implements a columnar store for PostgreSQL. Columnar stores
-provide notable benefits for analytic use-cases where data is loaded in batches.
+Cstore is a columnar store extension for PostgreSQL. Columnar stores provide notable benefits for analytic use-cases where data is loaded in batches.
 
-Join the [Mailing List][mailing-list] to stay on top of the latest developments.
+Cstore was created and is maintained by [Citus Data](https://www.citusdata.com). At Citus, our mission is to make it so you never have to worry about scaling again. We do this by allowing you to seamlessly scale out your Postgres database. The Citus extension is available as open source, an enterprise version, and a fully managed database as a service. If you have any questions about how Citus can help you scale please [let us know](https://www.citusdata.com/about/contact_us/).
+
+Join the [Mailing List][mailing-list] to stay on top of the latest developments for Cstore.
 
 
 Introduction

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ installation's bin/ directory path. For example:
     PATH=/usr/local/pgsql/bin/:$PATH make
     sudo PATH=/usr/local/pgsql/bin/:$PATH make install
 
-**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5 or 9.6. It doesn't
+**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10. It doesn't
 support earlier versions of PostgreSQL.
 
 
@@ -115,13 +115,13 @@ most efficient execution plan for each query.
 commands. We also don't support single row inserts.
 
 
-Updating from earlier versions to 1.5
+Updating from earlier versions to 1.6
 ---------------------------------------
 
-To update an existing cstore_fdw installation from versions earlier than 1.5
+To update an existing cstore_fdw installation from versions earlier than 1.6
 you can take the following steps:
 
-* Download and install cstore_fdw version 1.5 using instructions from the "Building"
+* Download and install cstore_fdw version 1.6 using instructions from the "Building"
   section,
 * Restart the PostgreSQL server,
 * Run ```ALTER EXTENSION cstore_fdw UPDATE;```
@@ -284,11 +284,20 @@ the installation:
 
 Changeset
 ---------
+### Version 1.6
+* (Feature) Added support for PostgreSQL 10.
+* (Fix) Removed table files when a schema, extension or database is dropped.
+* (Fix) Removed unused code fragments.
+* (Fix) Fixed incorrect initialization of stripe buffers.
+* (Fix) Checked user access rights when executing truncate.
+* (Fix) Made copy command cancellable.
+* (Fix) Fixed namespace issue regarding drop table.
+
 ### Version 1.5.1
 * (Fix) Verify cstore_fdw server on CREATE FOREIGN TABLE command
 
 ### Version 1.5
-* (Feature) Added support for PostgresSQL 9.6.
+* (Feature) Added support for PostgreSQL 9.6.
 * (Fix) Removed table data when cstore_fdw table is indirectly dropped.
 * (Fix) Removed unused code fragments.
 * (Fix) Fixed column selection logic to return columns used in expressions.
@@ -334,7 +343,7 @@ Changeset
 Copyright
 ---------
 
-Copyright (c) 2016 Citus Data, Inc.
+Copyright (c) 2017 Citus Data, Inc.
 
 This module is free software; you can redistribute it and/or modify it under the
 Apache v2.0 License.

--- a/cstore.proto
+++ b/cstore.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package protobuf;
 
 enum CompressionType {

--- a/cstore.proto
+++ b/cstore.proto
@@ -4,6 +4,8 @@ enum CompressionType {
   // Values should match with the corresponding struct in cstore_fdw.h
   NONE = 0;
   PG_LZ = 1;
+  SNAPPY = 2;
+  DEFLATE = 3;
 };
 
 message ColumnBlockSkipNode {

--- a/cstore_compression.c
+++ b/cstore_compression.c
@@ -205,9 +205,15 @@ DecompressBuffer(StringInfo buffer, CompressionType compressionType)
 		decompressedData = palloc0(decompressedDataSize);
 
 #if PG_VERSION_NUM >= 90500
+#if PG_VERSION_NUM >= 120000
 		decompressedByteCount = pglz_decompress(CSTORE_COMPRESS_RAWDATA(buffer->data),
-												compressedDataSize,
-												decompressedData, decompressedDataSize);
+												compressedDataSize, decompressedData,
+												decompressedDataSize, true);
+#else
+		decompressedByteCount = pglz_decompress(CSTORE_COMPRESS_RAWDATA(buffer->data),
+												compressedDataSize, decompressedData,
+												decompressedDataSize);
+#endif
 
 		if (decompressedByteCount < 0)
 		{

--- a/cstore_compression.c
+++ b/cstore_compression.c
@@ -205,6 +205,7 @@ DecompressBuffer(StringInfo buffer, CompressionType compressionType)
 		decompressedData = palloc0(decompressedDataSize);
 
 #if PG_VERSION_NUM >= 90500
+
 #if PG_VERSION_NUM >= 120000
 		decompressedByteCount = pglz_decompress(CSTORE_COMPRESS_RAWDATA(buffer->data),
 												compressedDataSize, decompressedData,

--- a/cstore_fdw--1.5--1.6.sql
+++ b/cstore_fdw--1.5--1.6.sql
@@ -1,9 +1,4 @@
-/* cstore_fdw/cstore_fdw--1.4--1.5.sql */
-
-CREATE FUNCTION cstore_clean_table_resources(oid)
-RETURNS void
-AS 'MODULE_PATHNAME'
-LANGUAGE C STRICT;
+/* cstore_fdw/cstore_fdw--1.5--1.6.sql */
 
 CREATE OR REPLACE FUNCTION cstore_drop_trigger()
 	RETURNS event_trigger
@@ -17,12 +12,8 @@ BEGIN
 			CONTINUE;
 		END IF;
 
-		PERFORM cstore_clean_table_resources(v_obj.objid);
+		PERFORM public.cstore_clean_table_resources(v_obj.objid);
 
 	END LOOP;
 END;
 $csdt$;
-
-CREATE EVENT TRIGGER cstore_drop_event
-	ON SQL_DROP
-	EXECUTE PROCEDURE cstore_drop_trigger();

--- a/cstore_fdw--1.5.sql
+++ b/cstore_fdw--1.5.sql
@@ -48,7 +48,7 @@ BEGIN
 			CONTINUE;
 		END IF;
 
-		PERFORM cstore_clean_table_resources(v_obj.objid);
+		PERFORM public.cstore_clean_table_resources(v_obj.objid);
 
 	END LOOP;
 END;
@@ -57,3 +57,4 @@ $csdt$;
 CREATE EVENT TRIGGER cstore_drop_event
     ON SQL_DROP
     EXECUTE PROCEDURE cstore_drop_trigger();
+

--- a/cstore_fdw--1.6--1.7.sql
+++ b/cstore_fdw--1.6--1.7.sql
@@ -1,0 +1,3 @@
+/* cstore_fdw/cstore_fdw--1.6--1.6.sql */
+
+-- No new functions or definitions were added in 1.7

--- a/cstore_fdw--1.6.sql
+++ b/cstore_fdw--1.6.sql
@@ -1,4 +1,4 @@
-/* cstore_fdw/cstore_fdw--1.5.sql */
+/* cstore_fdw/cstore_fdw--1.6.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION cstore_fdw" to load this file. \quit

--- a/cstore_fdw--1.7.sql
+++ b/cstore_fdw--1.7.sql
@@ -1,4 +1,4 @@
-/* cstore_fdw/cstore_fdw--1.6.sql */
+/* cstore_fdw/cstore_fdw--1.7.sql */
 
 -- complain if script is sourced in psql, rather than via CREATE EXTENSION
 \echo Use "CREATE EXTENSION cstore_fdw" to load this file. \quit

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1553,22 +1553,15 @@ ValidateForeignTableOptions(char *filename, char *compressionTypeString,
 
 /*
  * CStoreDefaultFilePath constructs the default file path to use for a cstore_fdw
- * table. The path is of the form $PGDATA/cstore_fdw/{databaseOid}/{relfilenode}.
+ * table. The path is of the form $PGDATA/cstore_fdw/{databaseOid}/{foreignTableId}.
  */
 static char *
 CStoreDefaultFilePath(Oid foreignTableId)
 {
-	Relation relation = relation_open(foreignTableId, AccessShareLock);
-	RelFileNode relationFileNode = relation->rd_node;
-
-	Oid databaseOid = relationFileNode.dbNode;
-	Oid relationFileOid = relationFileNode.relNode;
-
+	Oid databaseOid = MyDatabaseId;
 	StringInfo cstoreFilePath = makeStringInfo();
 	appendStringInfo(cstoreFilePath, "%s/%s/%u/%u", DataDir, CSTORE_FDW_NAME,
-					 databaseOid, relationFileOid);
-
-	relation_close(relation, AccessShareLock);
+					 databaseOid, foreignTableId);
 
 	return cstoreFilePath->data;
 }

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -43,7 +43,14 @@
 #include "optimizer/pathnode.h"
 #include "optimizer/planmain.h"
 #include "optimizer/restrictinfo.h"
+#if PG_VERSION_NUM >= 120000
+#include "access/heapam.h"
+#include "access/tableam.h"
+#include "executor/tuptable.h"
+#include "optimizer/optimizer.h"
+#else
 #include "optimizer/var.h"
+#endif
 #include "parser/parser.h"
 #include "parser/parsetree.h"
 #include "parser/parse_coerce.h"
@@ -55,7 +62,11 @@
 #include "utils/memutils.h"
 #include "utils/lsyscache.h"
 #include "utils/rel.h"
+#if PG_VERSION_NUM >= 120000
+#include "utils/snapmgr.h"
+#else
 #include "utils/tqual.h"
+#endif
 
 
 /* local functions forward declarations */
@@ -94,6 +105,7 @@ static bool DirectoryExists(StringInfo directoryName);
 static void CreateDirectory(StringInfo directoryName);
 static void RemoveCStoreDatabaseDirectory(Oid databaseOid);
 static StringInfo OptionNamesString(Oid currentContextId);
+static HeapTuple GetSlotHeapTuple(TupleTableSlot *tts);
 static CStoreFdwOptions * CStoreGetOptions(Oid foreignTableId);
 static char * CStoreGetOptionValue(Oid foreignTableId, const char *optionName);
 static void ValidateForeignTableOptions(char *filename, char *compressionTypeString,
@@ -147,7 +159,6 @@ static void CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relatio
 static bool CStoreIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel,
 											RangeTblEntry *rte);
 #endif
-
 
 /* declarations for dynamic loading */
 PG_MODULE_MAGIC;
@@ -579,7 +590,11 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 	{
 		/* read the next row in tupleContext */
 		MemoryContext oldContext = MemoryContextSwitchTo(tupleContext);
+#if PG_VERSION_NUM >= 120000
+		nextRowFound = NextCopyFrom(copyState, NULL, columnValues, columnNulls);
+#else
 		nextRowFound = NextCopyFrom(copyState, NULL, columnValues, columnNulls, NULL);
+#endif
 		MemoryContextSwitchTo(oldContext);
 
 		/* write the row to the cstore file */
@@ -793,7 +808,7 @@ FindCStoreTables(List *tableList)
 }
 
 
-/* 
+/*
  * OpenRelationsForTruncate opens and locks relations for tables to be truncated.
  *
  * It also performs a permission checks to see if the user has truncate privilege
@@ -971,9 +986,15 @@ DistributedTable(Oid relationId)
 	bool distributedTable = false;
 	Oid partitionOid = InvalidOid;
 	Relation heapRelation = NULL;
+#if PG_VERSION_NUM >= 120000
+	TableScanDesc scanDesc = NULL;
+#define heap_beginscan table_beginscan
+#define heap_endscan table_endscan
+#else
 	HeapScanDesc scanDesc = NULL;
+#endif
 	const int scanKeyCount = 1;
-	ScanKeyData scanKey[scanKeyCount];
+	ScanKeyData scanKey[1];
 	HeapTuple heapTuple = NULL;
 
 	bool missingOK = true;
@@ -1115,7 +1136,7 @@ CreateDirectory(StringInfo directoryName)
 
 /*
  * RemoveCStoreDatabaseDirectory removes CStore directory previously
- * created for this database. 
+ * created for this database.
  * However it does not remove 'cstore_fdw' directory even if there
  * are no other databases left.
  */
@@ -1366,6 +1387,18 @@ OptionNamesString(Oid currentContextId)
 	return optionNamesString;
 }
 
+/*
+ * GetSlotHeapTuple abstracts getting HeapTuple from TupleTableSlot between versions
+ */
+static HeapTuple
+GetSlotHeapTuple(TupleTableSlot *tts)
+{
+#if PG_VERSION_NUM >= 120000
+	return tts->tts_ops->copy_heap_tuple(tts);
+#else
+	return tts->tts_tuple;
+#endif
+}
 
 /*
  * CStoreGetOptions returns the option values to be used when reading and writing
@@ -1526,7 +1559,7 @@ static char *
 CStoreDefaultFilePath(Oid foreignTableId)
 {
 	Relation relation = relation_open(foreignTableId, AccessShareLock);
-	RelFileNode relationFileNode = relation->rd_node; 
+	RelFileNode relationFileNode = relation->rd_node;
 
 	Oid databaseOid = relationFileNode.dbNode;
 	Oid relationFileOid = relationFileNode.relNode;
@@ -2086,7 +2119,9 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 	/* set up tuple slot */
 	columnValues = palloc0(columnCount * sizeof(Datum));
 	columnNulls = palloc0(columnCount * sizeof(bool));
-#if PG_VERSION_NUM >= 110000
+#if PG_VERSION_NUM >= 120000
+	scanTupleSlot = MakeTupleTableSlot(NULL, &TTSOpsVirtual);
+#elif PG_VERSION_NUM >= 110000
 	scanTupleSlot = MakeTupleTableSlot(NULL);
 #else
 	scanTupleSlot = MakeTupleTableSlot();
@@ -2131,7 +2166,11 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 		MemoryContextSwitchTo(oldContext);
 
 		/* if there are no more records to read, break */
+#if PG_VERSION_NUM >= 120000
+		if (TTS_EMPTY(scanTupleSlot))
+#else
 		if (scanTupleSlot->tts_isempty)
+#endif
 		{
 			break;
 		}
@@ -2306,14 +2345,18 @@ CStoreExecForeignInsert(EState *executorState, ResultRelInfo *relationInfo,
 						TupleTableSlot *tupleSlot, TupleTableSlot *planSlot)
 {
 	TableWriteState *writeState = (TableWriteState*) relationInfo->ri_FdwState;
+	HeapTuple heapTuple;
 
 	Assert(writeState != NULL);
 
-	if(HeapTupleHasExternal(tupleSlot->tts_tuple))
+	heapTuple = GetSlotHeapTuple(tupleSlot);
+
+	if (HeapTupleHasExternal(heapTuple))
 	{
 		/* detoast any toasted attributes */
-		tupleSlot->tts_tuple = toast_flatten_tuple(tupleSlot->tts_tuple,
-												   tupleSlot->tts_tupleDescriptor);
+		HeapTuple newTuple = toast_flatten_tuple(heapTuple,
+												 tupleSlot->tts_tupleDescriptor);
+		ExecForceStoreHeapTuple(newTuple, tupleSlot, true);
 	}
 
 	slot_getallattrs(tupleSlot);

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1138,7 +1138,10 @@ RemoveCStoreDatabaseDirectory(Oid databaseOid)
 	appendStringInfo(cstoreDatabaseDirectoryPath, "%s/%s/%u", DataDir,
 					 CSTORE_FDW_NAME, databaseOid);
 
-	rmtree(cstoreDatabaseDirectoryPath->data, true);
+	if (DirectoryExists(cstoreDatabaseDirectoryPath))
+	{
+		rmtree(cstoreDatabaseDirectoryPath->data, true);
+	}
 }
 
 

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -986,13 +986,7 @@ DistributedTable(Oid relationId)
 	bool distributedTable = false;
 	Oid partitionOid = InvalidOid;
 	Relation heapRelation = NULL;
-#if PG_VERSION_NUM >= 120000
 	TableScanDesc scanDesc = NULL;
-#define heap_beginscan table_beginscan
-#define heap_endscan table_endscan
-#else
-	HeapScanDesc scanDesc = NULL;
-#endif
 	const int scanKeyCount = 1;
 	ScanKeyData scanKey[1];
 	HeapTuple heapTuple = NULL;
@@ -1017,13 +1011,13 @@ DistributedTable(Oid relationId)
 	ScanKeyInit(&scanKey[0], ATTR_NUM_PARTITION_RELATION_ID, InvalidStrategy,
 				F_OIDEQ, ObjectIdGetDatum(relationId));
 
-	scanDesc = heap_beginscan(heapRelation, SnapshotSelf, scanKeyCount, scanKey);
+	scanDesc = table_beginscan(heapRelation, SnapshotSelf, scanKeyCount, scanKey);
 
 	heapTuple = heap_getnext(scanDesc, ForwardScanDirection);
 
 	distributedTable = HeapTupleIsValid(heapTuple);
 
-	heap_endscan(scanDesc);
+	table_endscan(scanDesc);
 	relation_close(heapRelation, AccessShareLock);
 
 	return distributedTable;

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -2175,11 +2175,7 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 		MemoryContextSwitchTo(oldContext);
 
 		/* if there are no more records to read, break */
-#if PG_VERSION_NUM >= 120000
 		if (TTS_EMPTY(scanTupleSlot))
-#else
-		if (scanTupleSlot->tts_isempty)
-#endif
 		{
 			break;
 		}
@@ -2365,6 +2361,7 @@ CStoreExecForeignInsert(EState *executorState, ResultRelInfo *relationInfo,
 		/* detoast any toasted attributes */
 		HeapTuple newTuple = toast_flatten_tuple(heapTuple,
 												 tupleSlot->tts_tupleDescriptor);
+
 		ExecForceStoreHeapTuple(newTuple, tupleSlot, true);
 	}
 

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -493,6 +493,8 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 		}
 
 		MemoryContextReset(tupleContext);
+
+		CHECK_FOR_INTERRUPTS();
 	}
 
 	/* end read/write sessions and close the relation */

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -135,11 +135,14 @@ static List * CStorePlanForeignModify(PlannerInfo *plannerInfo, ModifyTable *pla
 static void CStoreBeginForeignModify(ModifyTableState *modifyTableState,
 									 ResultRelInfo *relationInfo, List *fdwPrivate,
 									 int subplanIndex, int executorflags);
+static void CStoreBeginForeignInsert(ModifyTableState *modifyTableState,
+									 ResultRelInfo *relationInfo);
 static TupleTableSlot * CStoreExecForeignInsert(EState *executorState,
 												ResultRelInfo *relationInfo,
 												TupleTableSlot *tupleSlot,
 												TupleTableSlot *planSlot);
 static void CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo);
+static void CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo);
 
 
 /* declarations for dynamic loading */
@@ -1206,6 +1209,11 @@ cstore_fdw_handler(PG_FUNCTION_ARGS)
 	fdwRoutine->ExecForeignInsert = CStoreExecForeignInsert;
 	fdwRoutine->EndForeignModify = CStoreEndForeignModify;
 
+#if PG_VERSION_NUM >= 110000
+	fdwRoutine->BeginForeignInsert = CStoreBeginForeignInsert;
+	fdwRoutine->EndForeignInsert = CStoreEndForeignInsert;
+#endif
+
 	PG_RETURN_POINTER(fdwRoutine);
 }
 
@@ -2231,18 +2239,15 @@ CStorePlanForeignModify(PlannerInfo *plannerInfo, ModifyTable *plan,
 }
 
 
-/* CStoreBeginForeignModify prepares cstore table for insert operation. */
+/*
+ * CStoreBeginForeignModify prepares cstore table for a modification.
+ * Only insert is currently supported.
+ */
 static void
 CStoreBeginForeignModify(ModifyTableState *modifyTableState,
 						 ResultRelInfo *relationInfo, List *fdwPrivate,
 						 int subplanIndex, int executorFlags)
 {
-	Oid  foreignTableOid = InvalidOid;
-	CStoreFdwOptions *cstoreFdwOptions = NULL;
-	TupleDesc tupleDescriptor = NULL;
-	TableWriteState *writeState = NULL;
-	Relation relation = NULL;
-
 	/* if Explain with no Analyze, do nothing */
 	if (executorFlags & EXEC_FLAG_EXPLAIN_ONLY)
 	{
@@ -2250,6 +2255,23 @@ CStoreBeginForeignModify(ModifyTableState *modifyTableState,
 	}
 
 	Assert (modifyTableState->operation == CMD_INSERT);
+
+	CStoreBeginForeignInsert(modifyTableState, relationInfo);
+}
+
+
+/*
+ * CStoreBeginForeignInsert prepares a cstore table for an insert or rows
+ * coming from a COPY.
+ */
+static void
+CStoreBeginForeignInsert(ModifyTableState *modifyTableState, ResultRelInfo *relationInfo)
+{
+	Oid  foreignTableOid = InvalidOid;
+	CStoreFdwOptions *cstoreFdwOptions = NULL;
+	TupleDesc tupleDescriptor = NULL;
+	TableWriteState *writeState = NULL;
+	Relation relation = NULL;
 
 	foreignTableOid = RelationGetRelid(relationInfo->ri_RelationDesc);
 	relation = heap_open(foreignTableOid, ShareUpdateExclusiveLock);
@@ -2294,9 +2316,22 @@ CStoreExecForeignInsert(EState *executorState, ResultRelInfo *relationInfo,
 }
 
 
-/* CStoreEndForeignModify ends the current insert operation. */
+/*
+ * CStoreEndForeignModify ends the current modification. Only insert is currently
+ * supported.
+ */
 static void
 CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo)
+{
+	CStoreEndForeignInsert(executorState, relationInfo);
+}
+
+
+/*
+ * CStoreEndForeignInsert ends the current insert or COPY operation.
+ */
+static void
+CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo)
 {
 	TableWriteState *writeState = (TableWriteState*) relationInfo->ri_FdwState;
 
@@ -2309,4 +2344,3 @@ CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo)
 		heap_close(relation, ShareUpdateExclusiveLock);
 	}
 }
-

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1364,6 +1364,14 @@ ParseCompressionType(const char *compressionTypeString)
 	{
 		compressionType = COMPRESSION_PG_LZ;
 	}
+	else if (strncmp(compressionTypeString, COMPRESSION_STRING_SNAPPY, NAMEDATALEN) == 0)
+	{
+		compressionType = COMPRESSION_SNAPPY;
+	}
+	else if (strncmp(compressionTypeString, COMPRESSION_STRING_DEFLATE, NAMEDATALEN) == 0)
+	{
+		compressionType = COMPRESSION_DEFLATE;
+	}
 
 	return compressionType;
 }

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -143,6 +143,10 @@ static TupleTableSlot * CStoreExecForeignInsert(EState *executorState,
 												TupleTableSlot *planSlot);
 static void CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo);
 static void CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo);
+#if PG_VERSION_NUM >= 90600
+static bool CStoreIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel,
+											RangeTblEntry *rte);
+#endif
 
 
 /* declarations for dynamic loading */
@@ -1212,6 +1216,10 @@ cstore_fdw_handler(PG_FUNCTION_ARGS)
 #if PG_VERSION_NUM >= 110000
 	fdwRoutine->BeginForeignInsert = CStoreBeginForeignInsert;
 	fdwRoutine->EndForeignInsert = CStoreEndForeignInsert;
+#endif
+
+#if PG_VERSION_NUM >= 90600
+	fdwRoutine->IsForeignScanParallelSafe = CStoreIsForeignScanParallelSafe;
 #endif
 
 	PG_RETURN_POINTER(fdwRoutine);
@@ -2344,3 +2352,23 @@ CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo)
 		heap_close(relation, ShareUpdateExclusiveLock);
 	}
 }
+
+
+#if PG_VERSION_NUM >= 90600
+/*
+ * CStoreIsForeignScanParallelSafe always returns true to indicate that
+ * reading from a cstore_fdw table in a parallel worker is safe. This
+ * does not enable parallelism for queries on individual cstore_fdw
+ * tables, but does allow parallel scans of cstore_fdw partitions.
+ *
+ * cstore_fdw is parallel-safe because all writes are immediately committed
+ * to disk and then read from disk. There is no uncommitted state that needs
+ * to be shared across processes.
+ */
+static bool
+CStoreIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel,
+								RangeTblEntry *rte)
+{
+	return true;
+}
+#endif

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -16,6 +16,7 @@
 
 #include "postgres.h"
 #include "cstore_fdw.h"
+#include "cstore_version_compat.h"
 
 #include <sys/stat.h>
 #include <unistd.h>
@@ -56,20 +57,6 @@
 #include "utils/rel.h"
 #include "utils/tqual.h"
 
-
-#define PREVIOUS_UTILITY (PreviousProcessUtilityHook != NULL \
-						  ? PreviousProcessUtilityHook : standard_ProcessUtility)
-#if PG_VERSION_NUM >= 100000
-#define CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, \
-							  destReceiver, completionTag) \
-	PREVIOUS_UTILITY(plannedStatement, queryString, context, paramListInfo, \
-					 queryEnvironment, destReceiver, completionTag)
-#else
-#define CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, \
-							  destReceiver, completionTag) \
-	PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, destReceiver, \
-					 completionTag)
-#endif
 
 /* local functions forward declarations */
 #if PG_VERSION_NUM >= 100000
@@ -552,9 +539,7 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 	 */
 	tupleContext = AllocSetContextCreate(CurrentMemoryContext,
 										 "CStore COPY Row Memory Context",
-										 ALLOCSET_DEFAULT_MINSIZE,
-										 ALLOCSET_DEFAULT_INITSIZE,
-										 ALLOCSET_DEFAULT_MAXSIZE);
+										 ALLOCSET_DEFAULT_SIZES);
 
 	/* init state to read from COPY data source */
 #if (PG_VERSION_NUM >= 100000)
@@ -822,7 +807,7 @@ OpenRelationsForTruncate(List *cstoreTableList)
 											   ACL_TRUNCATE);
 		if (aclresult != ACLCHECK_OK)
 		{
-			aclcheck_error(aclresult, ACL_KIND_CLASS, get_rel_name(relationId));
+			aclcheck_error(aclresult, ACLCHECK_OBJECT_TABLE, get_rel_name(relationId));
 		}
 
 		/* check if this relation is repeated */
@@ -1803,7 +1788,6 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 	const AttrNumber wholeRow = 0;
 	Relation relation = heap_open(foreignTableId, AccessShareLock);
 	TupleDesc tupleDescriptor = RelationGetDescr(relation);
-	Form_pg_attribute *attributeFormArray = tupleDescriptor->attrs;
 
 	/* first add the columns used in joins and projections */
 	foreach(targetColumnCell, targetColumnList)
@@ -1862,7 +1846,7 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 			}
 			else if (neededColumn->varattno == wholeRow)
 			{
-				Form_pg_attribute attributeForm = attributeFormArray[columnIndex - 1];
+				Form_pg_attribute attributeForm =  TupleDescAttr(tupleDescriptor, columnIndex - 1);
 				Index tableId = neededColumn->varno;
 
 				column = makeVar(tableId, columnIndex, attributeForm->atttypid,
@@ -1915,8 +1899,8 @@ CStoreBeginForeignScan(ForeignScanState *scanState, int executorFlags)
 	TableReadState *readState = NULL;
 	Oid foreignTableId = InvalidOid;
 	CStoreFdwOptions *cstoreFdwOptions = NULL;
-	TupleTableSlot *tupleSlot = scanState->ss.ss_ScanTupleSlot;
-	TupleDesc tupleDescriptor = tupleSlot->tts_tupleDescriptor;
+	Relation currentRelation = scanState->ss.ss_currentRelation;
+	TupleDesc tupleDescriptor = RelationGetDescr(currentRelation);
 	List *columnList = NIL;
 	ForeignScan *foreignScan = NULL;
 	List *foreignPrivateList = NIL;
@@ -2061,13 +2045,13 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 
 	TupleDesc tupleDescriptor = RelationGetDescr(relation);
 	uint32 columnCount = tupleDescriptor->natts;
-	Form_pg_attribute *attributeFormArray = tupleDescriptor->attrs;
+
 
 	/* create list of columns of the relation */
 	uint32 columnIndex = 0;
 	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
-		Form_pg_attribute attributeForm = attributeFormArray[columnIndex];
+		Form_pg_attribute attributeForm = TupleDescAttr(tupleDescriptor, columnIndex);
 		const Index tableId = 1;
 
 		if (!attributeForm->attisdropped)
@@ -2086,7 +2070,11 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 	/* set up tuple slot */
 	columnValues = palloc0(columnCount * sizeof(Datum));
 	columnNulls = palloc0(columnCount * sizeof(bool));
+#if PG_VERSION_NUM >= 110000
+	scanTupleSlot = MakeTupleTableSlot(NULL);
+#else
 	scanTupleSlot = MakeTupleTableSlot();
+#endif
 	scanTupleSlot->tts_tupleDescriptor = tupleDescriptor;
 	scanTupleSlot->tts_values = columnValues;
 	scanTupleSlot->tts_isnull = columnNulls;
@@ -2103,9 +2091,7 @@ CStoreAcquireSampleRows(Relation relation, int logLevel,
 	 */
 	tupleContext = AllocSetContextCreate(CurrentMemoryContext,
 										 "cstore_fdw temporary context",
-										 ALLOCSET_DEFAULT_MINSIZE,
-										 ALLOCSET_DEFAULT_INITSIZE,
-										 ALLOCSET_DEFAULT_MAXSIZE);
+										 ALLOCSET_DEFAULT_SIZES);
 
 	CStoreBeginForeignScan(scanState, executorFlags);
 

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -360,6 +360,11 @@ CStoreProcessUtility(Node * parseTree, const char *queryString,
 
 			CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo,
 								  destReceiver, completionTag);
+                        /* restore the former relation list. Our
+                         * replacement could be freed but still needed
+                         * in a cached plan. A truncate can be cached
+                         * if run from a pl/pgSQL function */
+                        truncateStatement->relations = allTablesList;
 		}
 
 		TruncateCStoreTables(cstoreRelationList);

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1886,6 +1886,12 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 	{
 		ListCell *neededColumnCell = NULL;
 		Var *column = NULL;
+		Form_pg_attribute attributeForm =  TupleDescAttr(tupleDescriptor, columnIndex - 1);
+
+		if (attributeForm->attisdropped)
+		{
+			continue;
+		}
 
 		/* look for this column in the needed column list */
 		foreach(neededColumnCell, neededColumnList)
@@ -1898,7 +1904,6 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 			}
 			else if (neededColumn->varattno == wholeRow)
 			{
-				Form_pg_attribute attributeForm =  TupleDescAttr(tupleDescriptor, columnIndex - 1);
 				Index tableId = neededColumn->varno;
 
 				column = makeVar(tableId, columnIndex, attributeForm->atttypid,

--- a/cstore_fdw.control
+++ b/cstore_fdw.control
@@ -1,5 +1,5 @@
 # cstore_fdw extension
 comment = 'foreign-data wrapper for flat cstore access'
-default_version = '1.6'
+default_version = '1.7'
 module_pathname = '$libdir/cstore_fdw'
 relocatable = true

--- a/cstore_fdw.control
+++ b/cstore_fdw.control
@@ -1,5 +1,5 @@
 # cstore_fdw extension
 comment = 'foreign-data wrapper for flat cstore access'
-default_version = '1.5'
+default_version = '1.6'
 module_pathname = '$libdir/cstore_fdw'
 relocatable = true

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -50,7 +50,7 @@
 /* CStore file signature */
 #define CSTORE_MAGIC_NUMBER "citus_cstore"
 #define CSTORE_VERSION_MAJOR 1
-#define CSTORE_VERSION_MINOR 5
+#define CSTORE_VERSION_MINOR 6
 
 /* miscellaneous defines */
 #define CSTORE_FDW_NAME "cstore_fdw"

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -43,7 +43,9 @@
 /* String representations of compression types */
 #define COMPRESSION_STRING_NONE "none"
 #define COMPRESSION_STRING_PG_LZ "pglz"
-#define COMPRESSION_STRING_DELIMITED_LIST "none, pglz"
+#define COMPRESSION_STRING_SNAPPY "snappy"
+#define COMPRESSION_STRING_DEFLATE "deflate"
+#define COMPRESSION_STRING_DELIMITED_LIST "none, pglz, snappy, deflate"
 
 /* CStore file signature */
 #define CSTORE_MAGIC_NUMBER "citus_cstore"
@@ -99,6 +101,8 @@ typedef enum
 	COMPRESSION_TYPE_INVALID = -1,
 	COMPRESSION_NONE = 0,
 	COMPRESSION_PG_LZ = 1,
+	COMPRESSION_SNAPPY = 2,
+	COMPRESSION_DEFLATE = 3,
 
 	COMPRESSION_COUNT
 

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -50,7 +50,7 @@
 /* CStore file signature */
 #define CSTORE_MAGIC_NUMBER "citus_cstore"
 #define CSTORE_VERSION_MAJOR 1
-#define CSTORE_VERSION_MINOR 6
+#define CSTORE_VERSION_MINOR 7
 
 /* miscellaneous defines */
 #define CSTORE_FDW_NAME "cstore_fdw"

--- a/cstore_fdw.h
+++ b/cstore_fdw.h
@@ -316,6 +316,7 @@ extern Datum cstore_ddl_event_end_trigger(PG_FUNCTION_ARGS);
 
 /* Function declarations for utility UDFs */
 extern Datum cstore_table_size(PG_FUNCTION_ARGS);
+extern Datum cstore_clean_table_resources(PG_FUNCTION_ARGS);
 
 /* Function declarations for foreign data wrapper */
 extern Datum cstore_fdw_handler(PG_FUNCTION_ARGS);

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -789,7 +789,11 @@ SelectedBlockMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 							 blockSkipNode->maximumValue);
 
 			constraintList = list_make1(baseConstraint);
+#if (PG_VERSION_NUM >= 100000)
+			predicateRefuted = predicate_refuted_by(constraintList, restrictInfoList, false);
+#else
 			predicateRefuted = predicate_refuted_by(constraintList, restrictInfoList);
+#endif
 			if (predicateRefuted)
 			{
 				selectedBlockMask[blockIndex] = false;

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -54,6 +54,7 @@ static StripeSkipList * LoadStripeSkipList(FILE *tableFile,
 										   StripeMetadata *stripeMetadata,
 										   StripeFooter *stripeFooter,
 										   uint32 columnCount,
+										   bool *projectedColumnMask,
 										   Form_pg_attribute *attributeFormArray);
 static bool * SelectedBlockMask(StripeSkipList *stripeSkipList,
 								List *projectedColumnList, List *whereClauseList);
@@ -63,6 +64,7 @@ static OpExpr * MakeOpExpression(Var *variable, int16 strategyNumber);
 static Oid GetOperatorByType(Oid typeId, Oid accessMethodId, int16 strategyNumber);
 static void UpdateConstraint(Node *baseConstraint, Datum minValue, Datum maxValue);
 static StripeSkipList * SelectedBlockSkipList(StripeSkipList *stripeSkipList,
+		 	 	 	 	 	 	 	 	 	  bool *projectedColumnMask,
 											  bool *selectedBlockMask);
 static uint32 StripeSkipListRowCount(StripeSkipList *stripeSkipList);
 static bool * ProjectedColumnMask(uint32 columnCount, List *projectedColumnList);
@@ -477,16 +479,19 @@ LoadFilteredStripeBuffers(FILE *tableFile, StripeMetadata *stripeMetadata,
 
 	StripeFooter *stripeFooter = LoadStripeFooter(tableFile, stripeMetadata,
 												  columnCount);
+	bool *projectedColumnMask = ProjectedColumnMask(columnCount, projectedColumnList);
+
 	StripeSkipList *stripeSkipList = LoadStripeSkipList(tableFile, stripeMetadata,
 														stripeFooter, columnCount,
+														projectedColumnMask,
 														attributeFormArray);
 
-	bool *projectedColumnMask = ProjectedColumnMask(columnCount, projectedColumnList);
 	bool *selectedBlockMask = SelectedBlockMask(stripeSkipList, projectedColumnList,
 												whereClauseList);
 
-	StripeSkipList *selectedBlockSkipList = SelectedBlockSkipList(stripeSkipList,
-																  selectedBlockMask);
+	StripeSkipList *selectedBlockSkipList =
+		SelectedBlockSkipList(stripeSkipList, projectedColumnMask,
+							  selectedBlockMask);
 
 	/* load column data for projected columns */
 	columnBuffersArray = palloc0(columnCount * sizeof(ColumnBuffers *));
@@ -643,6 +648,7 @@ LoadStripeFooter(FILE *tableFile, StripeMetadata *stripeMetadata,
 static StripeSkipList *
 LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 				   StripeFooter *stripeFooter, uint32 columnCount,
+				   bool *projectedColumnMask,
 				   Form_pg_attribute *attributeFormArray)
 {
 	StripeSkipList *stripeSkipList = NULL;
@@ -665,15 +671,25 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 	for (columnIndex = 0; columnIndex < stripeColumnCount; columnIndex++)
 	{
 		uint64 columnSkipListSize = stripeFooter->skipListSizeArray[columnIndex];
-		Form_pg_attribute attributeForm = attributeFormArray[columnIndex];
+		bool firstColumn = columnIndex == 0;
 
-		StringInfo columnSkipListBuffer =
-			ReadFromFile(tableFile, currentColumnSkipListFileOffset, columnSkipListSize);
+		/*
+		 * Only selected columns' column skip lists are read. However, the first
+		 * column's skip list is read regardless of being selected. It is used by
+		 * StripeSkipListRowCount later.
+		 */
+		if (projectedColumnMask[columnIndex] || firstColumn)
+		{
+			Form_pg_attribute attributeForm = attributeFormArray[columnIndex];
 
-		ColumnBlockSkipNode *columnSkipList =
-			DeserializeColumnSkipList(columnSkipListBuffer, attributeForm->attbyval,
-									  attributeForm->attlen, stripeBlockCount);
-		blockSkipNodeArray[columnIndex] = columnSkipList;
+			StringInfo columnSkipListBuffer =
+				ReadFromFile(tableFile, currentColumnSkipListFileOffset,
+							 columnSkipListSize);
+			ColumnBlockSkipNode *columnSkipList =
+				DeserializeColumnSkipList(columnSkipListBuffer, attributeForm->attbyval,
+										  attributeForm->attlen, stripeBlockCount);
+			blockSkipNodeArray[columnIndex] = columnSkipList;
+		}
 
 		currentColumnSkipListFileOffset += columnSkipListSize;
 	}
@@ -683,6 +699,14 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 	{
 		ColumnBlockSkipNode *columnSkipList = NULL;
 		uint32 blockIndex = 0;
+		bool firstColumn = columnIndex == 0;
+
+		/* no need to create ColumnBlockSkipList if the column is not selected */
+		if (!projectedColumnMask[columnIndex] && !firstColumn)
+		{
+			blockSkipNodeArray[columnIndex] = NULL;
+			continue;
+		}
 
 		/* create empty ColumnBlockSkipNode for missing columns*/
 		columnSkipList = palloc0(stripeBlockCount * sizeof(ColumnBlockSkipNode));
@@ -961,7 +985,8 @@ UpdateConstraint(Node *baseConstraint, Datum minValue, Datum maxValue)
  * non-selected blocks are removed from the given stripeSkipList.
  */
 static StripeSkipList *
-SelectedBlockSkipList(StripeSkipList *stripeSkipList, bool *selectedBlockMask)
+SelectedBlockSkipList(StripeSkipList *stripeSkipList, bool *projectedColumnMask,
+					  bool *selectedBlockMask)
 {
 	StripeSkipList *SelectedBlockSkipList = NULL;
 	ColumnBlockSkipNode **selectedBlockSkipNodeArray = NULL;
@@ -982,6 +1007,17 @@ SelectedBlockSkipList(StripeSkipList *stripeSkipList, bool *selectedBlockMask)
 	for (columnIndex = 0; columnIndex < columnCount; columnIndex++)
 	{
 		uint32 selectedBlockIndex = 0;
+		bool firstColumn = columnIndex == 0;
+
+		/* first column's block skip node is always read */
+		if (!projectedColumnMask[columnIndex] && !firstColumn)
+		{
+			selectedBlockSkipNodeArray[columnIndex] = NULL;
+			continue;
+		}
+
+		Assert(stripeSkipList->blockSkipNodeArray[columnIndex] != NULL);
+
 		selectedBlockSkipNodeArray[columnIndex] = palloc0(selectedBlockCount *
 														  sizeof(ColumnBlockSkipNode));
 

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -689,15 +689,15 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 
 		for (blockIndex = 0; blockIndex < stripeBlockCount; blockIndex++)
 		{
-			columnSkipList->rowCount = 0;
-			columnSkipList->hasMinMax = false;
-			columnSkipList->minimumValue = 0;
-			columnSkipList->maximumValue = 0;
-			columnSkipList->existsBlockOffset = 0;
-			columnSkipList->valueBlockOffset = 0;
-			columnSkipList->existsLength = 0;
-			columnSkipList->valueLength = 0;
-			columnSkipList->valueCompressionType = COMPRESSION_NONE;
+			columnSkipList[blockIndex].rowCount = 0;
+			columnSkipList[blockIndex].hasMinMax = false;
+			columnSkipList[blockIndex].minimumValue = 0;
+			columnSkipList[blockIndex].maximumValue = 0;
+			columnSkipList[blockIndex].existsBlockOffset = 0;
+			columnSkipList[blockIndex].valueBlockOffset = 0;
+			columnSkipList[blockIndex].existsLength = 0;
+			columnSkipList[blockIndex].valueLength = 0;
+			columnSkipList[blockIndex].valueCompressionType = COMPRESSION_NONE;
 		}
 		blockSkipNodeArray[columnIndex] = columnSkipList;
 	}

--- a/cstore_version_compat.h
+++ b/cstore_version_compat.h
@@ -45,6 +45,10 @@
 					 completionTag)
 #endif
 
-
+#if PG_VERSION_NUM < 120000
+#define TTS_EMPTY(slot)	((slot)->tts_isempty)
+#define ExecForceStoreHeapTuple(tuple, slot, shouldFree) \
+		ExecStoreTuple(newTuple, tupleSlot, InvalidBuffer,  shouldFree);
+#endif
 
 #endif /* CSTORE_COMPAT_H */

--- a/cstore_version_compat.h
+++ b/cstore_version_compat.h
@@ -1,0 +1,50 @@
+/*-------------------------------------------------------------------------
+ *
+ * cstore_version_compat.h
+ *
+ * 	Compatibility macros for writing code agnostic to PostgreSQL versions
+ *
+ * Copyright (c) 2018, Citus Data, Inc.
+ *
+ * $Id$
+ *
+ *-------------------------------------------------------------------------
+ */
+
+#ifndef CSTORE_COMPAT_H
+#define CSTORE_COMPAT_H
+
+#if PG_VERSION_NUM < 100000
+
+/* Accessor for the i'th attribute of tupdesc. */
+#define TupleDescAttr(tupdesc, i) ((tupdesc)->attrs[(i)])
+
+#endif
+
+#if PG_VERSION_NUM < 110000
+#define ALLOCSET_DEFAULT_SIZES ALLOCSET_DEFAULT_MINSIZE, ALLOCSET_DEFAULT_INITSIZE, ALLOCSET_DEFAULT_MAXSIZE
+#define ACLCHECK_OBJECT_TABLE ACL_KIND_CLASS
+#else
+#define ACLCHECK_OBJECT_TABLE OBJECT_TABLE
+
+#define ExplainPropertyLong(qlabel, value, es) \
+	ExplainPropertyInteger(qlabel, NULL, value, es)
+#endif
+
+#define PREVIOUS_UTILITY (PreviousProcessUtilityHook != NULL \
+						  ? PreviousProcessUtilityHook : standard_ProcessUtility)
+#if PG_VERSION_NUM >= 100000
+#define CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, \
+							  destReceiver, completionTag) \
+	PREVIOUS_UTILITY(plannedStatement, queryString, context, paramListInfo, \
+					 queryEnvironment, destReceiver, completionTag)
+#else
+#define CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, \
+							  destReceiver, completionTag) \
+	PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo, destReceiver, \
+					 completionTag)
+#endif
+
+
+
+#endif /* CSTORE_COMPAT_H */

--- a/cstore_version_compat.h
+++ b/cstore_version_compat.h
@@ -49,6 +49,10 @@
 #define TTS_EMPTY(slot)	((slot)->tts_isempty)
 #define ExecForceStoreHeapTuple(tuple, slot, shouldFree) \
 		ExecStoreTuple(newTuple, tupleSlot, InvalidBuffer,  shouldFree);
+#define HeapScanDesc TableScanDesc
+#define table_beginscan heap_beginscan
+#define table_endscan heap_endscan
+
 #endif
 
 #endif /* CSTORE_COMPAT_H */

--- a/cstore_writer.c
+++ b/cstore_writer.c
@@ -23,7 +23,11 @@
 #include "access/nbtree.h"
 #include "catalog/pg_collation.h"
 #include "commands/defrem.h"
+#if PG_VERSION_NUM >= 120000
+#include "optimizer/optimizer.h"
+#else
 #include "optimizer/var.h"
+#endif
 #include "port.h"
 #include "storage/fd.h"
 #include "utils/memutils.h"
@@ -482,7 +486,7 @@ CreateEmptyStripeSkipList(uint32 stripeMaxRowCount, uint32 blockRowCount,
 
 /*
  * FlushStripe flushes current stripe data into the file. The function first ensures
- * the last data block for each column is properly serialized and compressed. Then, 
+ * the last data block for each column is properly serialized and compressed. Then,
  * the function creates the skip list and footer buffers. Finally, the function
  * flushes the skip list, data, and footer buffers to the file.
  */
@@ -751,7 +755,7 @@ SerializeSingleDatum(StringInfo datumBuffer, Datum datum, bool datumTypeByValue,
 		Assert(!datumTypeByValue);
 		memcpy(currentDatumDataPointer, DatumGetPointer(datum), datumLength);
 	}
-	
+
 	datumBuffer->len += datumLengthAligned;
 }
 

--- a/cstore_writer.c
+++ b/cstore_writer.c
@@ -798,7 +798,9 @@ SerializeBlockData(TableWriteState *writeState, uint32 blockIndex, uint32 rowCou
 
 		/* the only other supported compression type is pg_lz for now */
 		Assert(requestedCompressionType == COMPRESSION_NONE ||
-			   requestedCompressionType == COMPRESSION_PG_LZ);
+			   requestedCompressionType == COMPRESSION_PG_LZ ||
+			   requestedCompressionType == COMPRESSION_SNAPPY ||
+			   requestedCompressionType == COMPRESSION_DEFLATE);
 
 		/*
 		 * if serializedValueBuffer is be compressed, update serializedValueBuffer
@@ -809,7 +811,8 @@ SerializeBlockData(TableWriteState *writeState, uint32 blockIndex, uint32 rowCou
 		if (compressed)
 		{
 			serializedValueBuffer = compressionBuffer;
-			actualCompressionType = COMPRESSION_PG_LZ;
+//			actualCompressionType = COMPRESSION_PG_LZ;
+			actualCompressionType = requestedCompressionType;
 		}
 
 		/* store (compressed) value buffer */

--- a/expected/alter.out
+++ b/expected/alter.out
@@ -127,6 +127,18 @@ SELECT * from test_alter_table;
  1 | 4 | ABCDEF
 (7 rows)
 
+SELECT count(*) from test_alter_table;
+ count 
+-------
+     7
+(1 row)
+
+SELECT count(t.*) from test_alter_table t;
+ count 
+-------
+     7
+(1 row)
+
 -- unsupported default values
 ALTER FOREIGN TABLE test_alter_table ADD COLUMN g boolean DEFAULT isfinite(current_date);
 ALTER FOREIGN TABLE test_alter_table ADD COLUMN h DATE DEFAULT current_date;

--- a/expected/drop.out
+++ b/expected/drop.out
@@ -1,6 +1,17 @@
 --
--- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
+-- Tests the different DROP commands for cstore_fdw tables.
 --
+-- DROP FOREIGN TABL
+-- DROP SCHEMA
+-- DROP EXTENSION
+-- DROP DATABASE
+--
+-- Note that travis does not create
+-- cstore_fdw extension in default database (postgres). This has caused
+-- different behavior between travis tests and local tests. Thus
+-- 'postgres' directory is excluded from comparison to have the same result.
+-- store postgres database oid
+SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
 SELECT count(*) FROM (
@@ -29,5 +40,58 @@ SELECT count(*) FROM (
  count 
 -------
      0
+(1 row)
+
+SELECT current_database() datname \gset
+CREATE DATABASE db_to_drop;
+\c db_to_drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 files, data and footer file for single table
+SELECT count(*) FROM pg_ls_dir('cstore_fdw/' || :databaseoid);
+ count 
+-------
+     2
+(1 row)
+
+-- should see 2 directories 1 for each database, excluding postgres database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     2
+(1 row)
+
+DROP EXTENSION cstore_fdw CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to server cstore_server
+drop cascades to foreign table test_table
+-- should only see 1 directory here
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     1
+(1 row)
+
+-- test database drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 directories 1 for each database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     2
+(1 row)
+
+\c :datname
+DROP DATABASE db_to_drop;
+-- should only see 1 directory for the default database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     1
 (1 row)
 

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -155,6 +155,27 @@ SELECT * from cstore_truncate_test;
 ---+---
 (0 rows)
 
+-- test if a cached truncate from a pl/pgsql function works
+CREATE FUNCTION cstore_truncate_test_regular_func() RETURNS void AS $$
+BEGIN
+	INSERT INTO cstore_truncate_test_regular select a, a from generate_series(1, 10) a;
+	TRUNCATE TABLE cstore_truncate_test_regular;
+END;$$
+LANGUAGE plpgsql;
+SELECT cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
+
+-- the cached plans are used stating from the second call
+SELECT cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
+
+DROP FUNCTION cstore_truncate_test_regular_func();
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -1,6 +1,14 @@
 --
 -- Test the TRUNCATE TABLE command for cstore_fdw tables.
 --
+-- print whether we're using version > 10 to make version-specific tests clear
+SHOW server_version \gset
+SELECT substring(:'server_version', '\d+')::int > 10 AS version_above_ten;
+ version_above_ten 
+-------------------
+ t
+(1 row)
+
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
 SELECT count(*) FROM (
@@ -212,7 +220,7 @@ SELECT count(*) FROM truncate_schema.truncate_tbl;
 (1 row)
 
 TRUNCATE TABLE truncate_schema.truncate_tbl;
-ERROR:  permission denied for relation truncate_tbl
+ERROR:  permission denied for table truncate_tbl
 SELECT count(*) FROM truncate_schema.truncate_tbl;
  count 
 -------

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -15,8 +15,11 @@ SELECT count(*) FROM (
 -- CREATE a cstore_fdw table, fill with some data --
 CREATE FOREIGN TABLE cstore_truncate_test (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_second (a int, b int) SERVER cstore_server;
+CREATE FOREIGN TABLE cstore_truncate_test_compressed (a int, b int) SERVER cstore_server OPTIONS (compression 'pglz');
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
+INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
+INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
 -- query rows
 SELECT * FROM cstore_truncate_test;
  a  | b  
@@ -45,6 +48,25 @@ SELECT COUNT(*) from cstore_truncate_test;
      0
 (1 row)
 
+SELECT count(*) FROM cstore_truncate_test_compressed;
+ count 
+-------
+    20
+(1 row)
+
+TRUNCATE TABLE cstore_truncate_test_compressed;
+SELECT count(*) FROM cstore_truncate_test_compressed;
+ count 
+-------
+     0
+(1 row)
+
+SELECT cstore_table_size('cstore_truncate_test_compressed');
+ cstore_table_size 
+-------------------
+                26
+(1 row)
+
 -- make sure data files still present 
 SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
@@ -52,7 +74,7 @@ SELECT count(*) FROM (
 	) AS q1) AS q2;
  count 
 -------
-     4
+     6
 (1 row)
 
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
@@ -133,3 +155,4 @@ SELECT * from cstore_truncate_test;
 
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
+DROP FOREIGN TABLE cstore_truncate_test_compressed;

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -128,9 +128,11 @@ SELECT * from cstore_truncate_test_regular;
 (11 rows)
 
 -- make sure multi truncate works
-TRUNCATE TABLE cstore_truncate_test, 
+-- notice that the same table might be repeated
+TRUNCATE TABLE cstore_truncate_test,
 			   cstore_truncate_test_regular,
-			   cstore_truncate_test_second;
+			   cstore_truncate_test_second,
+   			   cstore_truncate_test;
 SELECT * from cstore_truncate_test;
  a | b 
 ---+---
@@ -156,3 +158,76 @@ SELECT * from cstore_truncate_test;
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;
+-- test truncate with schema
+CREATE SCHEMA truncate_schema;
+CREATE FOREIGN TABLE truncate_schema.truncate_tbl (id int) SERVER cstore_server OPTIONS(compression 'pglz');
+INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
+SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
+-- create a user that can not truncate
+CREATE USER truncate_user;
+GRANT USAGE ON SCHEMA truncate_schema TO truncate_user;
+GRANT SELECT ON TABLE truncate_schema.truncate_tbl TO truncate_user;
+REVOKE TRUNCATE ON TABLE truncate_schema.truncate_tbl FROM truncate_user;
+SELECT current_user \gset
+\c - truncate_user
+-- verify truncate command fails and check number of rows
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+ERROR:  permission denied for relation truncate_tbl
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+-- switch to super user, grant truncate to truncate_user 
+\c - :current_user
+GRANT TRUNCATE ON TABLE truncate_schema.truncate_tbl TO truncate_user;
+-- verify truncate_user can truncate now
+\c - truncate_user
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
+
+\c - :current_user
+-- cleanup
+DROP SCHEMA truncate_schema CASCADE;
+NOTICE:  drop cascades to foreign table truncate_schema.truncate_tbl
+DROP USER truncate_user;
+-- verify files are removed
+SELECT count(*) FROM (
+	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
+	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
+	) AS q1) AS q2;
+ count 
+-------
+     0
+(1 row)
+

--- a/expected/truncate_0.out
+++ b/expected/truncate_0.out
@@ -1,10 +1,13 @@
 --
 -- Test the TRUNCATE TABLE command for cstore_fdw tables.
 --
-
 -- print whether we're using version > 10 to make version-specific tests clear
 SHOW server_version \gset
 SELECT substring(:'server_version', '\d+')::int > 10 AS version_above_ten;
+ version_above_ten 
+-------------------
+ f
+(1 row)
 
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
@@ -12,48 +15,125 @@ SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
 	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
 	) AS q1) AS q2;
+ count 
+-------
+     0
+(1 row)
 
 -- CREATE a cstore_fdw table, fill with some data --
 CREATE FOREIGN TABLE cstore_truncate_test (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_second (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_compressed (a int, b int) SERVER cstore_server OPTIONS (compression 'pglz');
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
-
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
-
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
-
 -- query rows
 SELECT * FROM cstore_truncate_test;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
 
 TRUNCATE TABLE cstore_truncate_test;
-
 SELECT * FROM cstore_truncate_test;
+ a | b 
+---+---
+(0 rows)
 
 SELECT COUNT(*) from cstore_truncate_test;
+ count 
+-------
+     0
+(1 row)
 
 SELECT count(*) FROM cstore_truncate_test_compressed;
+ count 
+-------
+    20
+(1 row)
+
 TRUNCATE TABLE cstore_truncate_test_compressed;
 SELECT count(*) FROM cstore_truncate_test_compressed;
+ count 
+-------
+     0
+(1 row)
 
 SELECT cstore_table_size('cstore_truncate_test_compressed');
+ cstore_table_size 
+-------------------
+                26
+(1 row)
 
 -- make sure data files still present 
 SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
 	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
 	) AS q1) AS q2;
+ count 
+-------
+     6
+(1 row)
 
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 INSERT INTO cstore_truncate_test_regular select a, a from generate_series(10, 20) a;
 INSERT INTO cstore_truncate_test_second select a, a from generate_series(20, 30) a;
-
 SELECT * from cstore_truncate_test;
+ a  | b  
+----+----
+  1 |  1
+  2 |  2
+  3 |  3
+  4 |  4
+  5 |  5
+  6 |  6
+  7 |  7
+  8 |  8
+  9 |  9
+ 10 | 10
+(10 rows)
 
 SELECT * from cstore_truncate_test_second;
+ a  | b  
+----+----
+ 20 | 20
+ 21 | 21
+ 22 | 22
+ 23 | 23
+ 24 | 24
+ 25 | 25
+ 26 | 26
+ 27 | 27
+ 28 | 28
+ 29 | 29
+ 30 | 30
+(11 rows)
 
 SELECT * from cstore_truncate_test_regular;
+ a  | b  
+----+----
+ 10 | 10
+ 11 | 11
+ 12 | 12
+ 13 | 13
+ 14 | 14
+ 15 | 15
+ 16 | 16
+ 17 | 17
+ 18 | 18
+ 19 | 19
+ 20 | 20
+(11 rows)
 
 -- make sure multi truncate works
 -- notice that the same table might be repeated
@@ -61,14 +141,27 @@ TRUNCATE TABLE cstore_truncate_test,
 			   cstore_truncate_test_regular,
 			   cstore_truncate_test_second,
    			   cstore_truncate_test;
-
 SELECT * from cstore_truncate_test;
+ a | b 
+---+---
+(0 rows)
+
 SELECT * from cstore_truncate_test_second;
+ a | b 
+---+---
+(0 rows)
+
 SELECT * from cstore_truncate_test_regular;
+ a | b 
+---+---
+(0 rows)
 
 -- test if truncate on empty table works
 TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
+ a | b 
+---+---
+(0 rows)
 
 -- test if a cached truncate from a pl/pgsql function works
 CREATE FUNCTION cstore_truncate_test_regular_func() RETURNS void AS $$
@@ -77,59 +170,93 @@ BEGIN
 	TRUNCATE TABLE cstore_truncate_test_regular;
 END;$$
 LANGUAGE plpgsql;
-
 SELECT cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
+
 -- the cached plans are used stating from the second call
 SELECT cstore_truncate_test_regular_func();
-DROP FUNCTION cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
 
+DROP FUNCTION cstore_truncate_test_regular_func();
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;
-
 -- test truncate with schema
 CREATE SCHEMA truncate_schema;
 CREATE FOREIGN TABLE truncate_schema.truncate_tbl (id int) SERVER cstore_server OPTIONS(compression 'pglz');
 INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
 SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
 
 TRUNCATE TABLE truncate_schema.truncate_tbl;
 SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
 
 INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
-
 -- create a user that can not truncate
 CREATE USER truncate_user;
 GRANT USAGE ON SCHEMA truncate_schema TO truncate_user;
 GRANT SELECT ON TABLE truncate_schema.truncate_tbl TO truncate_user;
 REVOKE TRUNCATE ON TABLE truncate_schema.truncate_tbl FROM truncate_user;
-
 SELECT current_user \gset
-
 \c - truncate_user
 -- verify truncate command fails and check number of rows
 SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
 TRUNCATE TABLE truncate_schema.truncate_tbl;
+ERROR:  permission denied for relation truncate_tbl
 SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
 
 -- switch to super user, grant truncate to truncate_user 
 \c - :current_user
 GRANT TRUNCATE ON TABLE truncate_schema.truncate_tbl TO truncate_user;
-
 -- verify truncate_user can truncate now
 \c - truncate_user
 SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
 TRUNCATE TABLE truncate_schema.truncate_tbl;
 SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
 
 \c - :current_user
-
 -- cleanup
 DROP SCHEMA truncate_schema CASCADE;
+NOTICE:  drop cascades to foreign table truncate_schema.truncate_tbl
 DROP USER truncate_user;
-
 -- verify files are removed
 SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
 	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
 	) AS q1) AS q2;
+ count 
+-------
+     0
+(1 row)
+

--- a/output/create.source
+++ b/output/create.source
@@ -24,7 +24,7 @@ CREATE FOREIGN TABLE test_validator_invalid_compression_type ()
 	SERVER cstore_server
 	OPTIONS(filename 'data.cstore', compression 'invalid_compression'); -- ERROR
 ERROR:  invalid compression type
-HINT:  Valid options are: none, pglz
+HINT:  Valid options are: none, pglz, snappy, deflate
 -- Invalid file path test
 CREATE FOREIGN TABLE test_invalid_file_path ()
 	SERVER cstore_server

--- a/sql/alter.sql
+++ b/sql/alter.sql
@@ -53,6 +53,8 @@ ALTER FOREIGN TABLE test_alter_table DROP COLUMN c;
 ALTER FOREIGN TABLE test_alter_table DROP COLUMN e;
 ANALYZE test_alter_table;
 SELECT * from test_alter_table;
+SELECT count(*) from test_alter_table;
+SELECT count(t.*) from test_alter_table t;
 
 
 -- unsupported default values

--- a/sql/drop.sql
+++ b/sql/drop.sql
@@ -1,6 +1,19 @@
 --
--- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
+-- Tests the different DROP commands for cstore_fdw tables.
 --
+-- DROP FOREIGN TABL
+-- DROP SCHEMA
+-- DROP EXTENSION
+-- DROP DATABASE
+--
+
+-- Note that travis does not create
+-- cstore_fdw extension in default database (postgres). This has caused
+-- different behavior between travis tests and local tests. Thus
+-- 'postgres' directory is excluded from comparison to have the same result.
+
+-- store postgres database oid
+SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
@@ -24,3 +37,40 @@ SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
 	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
 	) AS q1) AS q2;
+
+SELECT current_database() datname \gset
+
+CREATE DATABASE db_to_drop;
+\c db_to_drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 files, data and footer file for single table
+SELECT count(*) FROM pg_ls_dir('cstore_fdw/' || :databaseoid);
+
+-- should see 2 directories 1 for each database, excluding postgres database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+DROP EXTENSION cstore_fdw CASCADE;
+
+-- should only see 1 directory here
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+-- test database drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+
+-- should see 2 directories 1 for each database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+\c :datname
+
+DROP DATABASE db_to_drop;
+
+-- should only see 1 directory for the default database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;

--- a/sql/truncate.sql
+++ b/sql/truncate.sql
@@ -66,6 +66,19 @@ SELECT * from cstore_truncate_test_regular;
 TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
 
+-- test if a cached truncate from a pl/pgsql function works
+CREATE FUNCTION cstore_truncate_test_regular_func() RETURNS void AS $$
+BEGIN
+	INSERT INTO cstore_truncate_test_regular select a, a from generate_series(1, 10) a;
+	TRUNCATE TABLE cstore_truncate_test_regular;
+END;$$
+LANGUAGE plpgsql;
+
+SELECT cstore_truncate_test_regular_func();
+-- the cached plans are used stating from the second call
+SELECT cstore_truncate_test_regular_func();
+DROP FUNCTION cstore_truncate_test_regular_func();
+
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;

--- a/sql/truncate.sql
+++ b/sql/truncate.sql
@@ -12,9 +12,13 @@ SELECT count(*) FROM (
 -- CREATE a cstore_fdw table, fill with some data --
 CREATE FOREIGN TABLE cstore_truncate_test (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_second (a int, b int) SERVER cstore_server;
+CREATE FOREIGN TABLE cstore_truncate_test_compressed (a int, b int) SERVER cstore_server OPTIONS (compression 'pglz');
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
 
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
+
+INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
+INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
 
 -- query rows
 SELECT * FROM cstore_truncate_test;
@@ -24,6 +28,12 @@ TRUNCATE TABLE cstore_truncate_test;
 SELECT * FROM cstore_truncate_test;
 
 SELECT COUNT(*) from cstore_truncate_test;
+
+SELECT count(*) FROM cstore_truncate_test_compressed;
+TRUNCATE TABLE cstore_truncate_test_compressed;
+SELECT count(*) FROM cstore_truncate_test_compressed;
+
+SELECT cstore_table_size('cstore_truncate_test_compressed');
 
 -- make sure data files still present 
 SELECT count(*) FROM (
@@ -56,3 +66,4 @@ SELECT * from cstore_truncate_test;
 
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
+DROP FOREIGN TABLE cstore_truncate_test_compressed;


### PR DESCRIPTION
Hello. I made some changes to enable snappy and deflate (via zlib) compression. As expected, basic testing shows snappy to be much less cpu-bound than pglz and deflate costlier, but providing higher compression rates.

At your convenience, shall we discuss if the code looks good to merge? Please note this is a very bare bones implementation, so please do criticize and recommend changes so I can improve it. I hope this proves useful somehow.

Thank you.