### PR TITLE
Add support for Postgres 10

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ env:
 before_install:
   - sudo apt-get update -qq
   - sudo update-alternatives --remove-all postmaster.1.gz
-  - git clone -b v0.5.1 --depth 1 https://github.com/citusdata/tools.git
+  - git clone -b v0.6.1 --depth 1 https://github.com/citusdata/tools.git
   - sudo make -C tools install
   - nuke_pg
 install:

--- a/Makefile
+++ b/Makefile
@@ -40,8 +40,8 @@ ifndef MAJORVERSION
     MAJORVERSION := $(basename $(VERSION))
 endif
 
-ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6))
-    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 is required to compile this extension)
+ifeq (,$(findstring $(MAJORVERSION), 9.3 9.4 9.5 9.6 10))
+    $(error PostgreSQL 9.3 or 9.4 or 9.5 or 9.6 or 10 is required to compile this extension)
 endif
 
 cstore.pb-c.c: cstore.proto


### PR DESCRIPTION
There are some API changes regarding process utility hooks,
raw_parser(), and DoCopy() function.
Added conditional conditional compilation definitions to
make cstore_fdw run with PG 10 without breaking compatibility for
previously supported PG versions (9.3, 9.4, 9.5, 9.6)