### PR TITLE
Use postgres internal storage and enable WAL

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -43,7 +43,6 @@
 /data/*.footer
 
 /sql/block_filtering.sql
-/sql/create.sql
 /sql/data_types.sql
 /sql/load.sql
 

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ DATA = cstore_fdw--1.5.sql cstore_fdw--1.4--1.5.sql cstore_fdw--1.3--1.4.sql \
 REGRESS = create load query analyze data_types functions block_filtering drop \
 		  insert copyto alter truncate
 EXTRA_CLEAN = cstore.pb-c.h cstore.pb-c.c data/*.cstore data/*.cstore.footer \
-              sql/block_filtering.sql sql/create.sql sql/data_types.sql sql/load.sql \
-              sql/copyto.sql expected/block_filtering.out expected/create.out \
+              sql/block_filtering.sql sql/data_types.sql sql/load.sql \
+			  sql/copyto.sql expected/block_filtering.out \
               expected/data_types.out expected/load.out expected/copyto.out
 
 ifeq ($(enable_coverage),yes)
@@ -32,7 +32,9 @@ endif
 # example: /usr/local/pgsql/bin/pg_config or /usr/lib/postgresql/9.3/bin/pg_config
 #
 
-PG_CONFIG = pg_config
+# PG_CONFIG = pg_config
+PG_CONFIG = /usr/local/pgsql/bin/pg_config
+
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)
 

--- a/cstore_fdw--1.5.sql
+++ b/cstore_fdw--1.5.sql
@@ -40,15 +40,15 @@ CREATE OR REPLACE FUNCTION cstore_drop_trigger()
 	RETURNS event_trigger
 	LANGUAGE plpgsql
 	AS $csdt$
-DECLARE v_obj record;
+DECLARE dropped_object record;
 BEGIN
-	FOR v_obj IN SELECT * FROM pg_event_trigger_dropped_objects() LOOP
+	FOR dropped_object IN SELECT * FROM pg_event_trigger_dropped_objects() LOOP
 
-		IF v_obj.object_type NOT IN ('table', 'foreign table') THEN
+		IF dropped_object.object_type <> 'foreign table' THEN
 			CONTINUE;
 		END IF;
 
-		PERFORM cstore_clean_table_resources(v_obj.objid);
+		PERFORM public.cstore_clean_table_resources(dropped_object.objid);
 
 	END LOOP;
 END;

--- a/cstore_metadata_serialization.c
+++ b/cstore_metadata_serialization.c
@@ -18,6 +18,7 @@
 #include "cstore_metadata_serialization.h"
 #include "cstore.pb-c.h"
 #include "access/tupmacs.h"
+#include "storage/buf.h"
 
 
 /* local functions forward declarations */
@@ -578,4 +579,78 @@ ProtobufBinaryToDatum(ProtobufCBinaryData protobufBinary, bool datumTypeByValue,
 	datum = fetch_att(binaryDataCopy, datumTypeByValue, datumTypeLength);
 
 	return datum;
+}
+
+
+/* DeserializeFooterMetadata deserializes footer metadata to extract where footer
+ * starts and length of footer data in number of pages.
+ * Expects to see cstore magic number (char[12]), major version (uint32), minor version(uint32)
+ * startingPage (uint32), pageCount (uint32)
+ */
+bool
+DeserializeTableFooterMetadata(const char *data, uint32 length, uint32 *startingPage,
+							   uint32 *pageCount)
+{
+	uint32 offset = 0;
+	char *magicNumber = pstrdup(CSTORE_MAGIC_NUMBER);
+	uint32 magicLength = strnlen(magicNumber, NAMEDATALEN);
+	uint32 footerMetadataLength = magicLength + 4 * sizeof(uint32);
+	uint32 majorVersion = 0;
+	uint32 minorVersion = 0;
+
+	*startingPage = InvalidBuffer;
+	*pageCount = InvalidBuffer;
+
+	if (length < footerMetadataLength)
+	{
+		return false;
+	}
+
+	if (memcmp(data, magicNumber, magicLength) != 0)
+	{
+		return false;
+	}
+
+	offset = magicLength;
+
+	memcpy(&majorVersion, data + offset, sizeof(uint32));
+	offset += sizeof(uint32);
+
+	memcpy(&minorVersion, data + offset, sizeof(uint32));
+	offset += sizeof(uint32);
+
+	if (majorVersion != CSTORE_VERSION_MAJOR ||
+		minorVersion != CSTORE_VERSION_MINOR)
+	{
+		ereport(ERROR, (errmsg("Unsupported cstore_fdw version")));
+	}
+
+	memcpy(startingPage, data + offset, sizeof(uint32));
+	offset += sizeof(uint32);
+
+	memcpy(pageCount, data + offset, sizeof(uint32));
+
+	return true;
+}
+
+
+/* SerializeTableFooterMetadata serializes footer metadata. Serialized string
+ * contains see cstore magic number (char[12]), major version (uint32),
+ * minor version(uint32), startingPage (uint32), pageCount (uint32)
+ */
+StringInfo
+SerializeTableFooterMetadata(uint32 startingPage, uint32 pageCount)
+{
+	StringInfo resultString = makeStringInfo();
+	uint32 majorVersion = CSTORE_VERSION_MAJOR;
+	uint32 minorVersion = CSTORE_VERSION_MINOR;
+
+	appendBinaryStringInfo(resultString, CSTORE_MAGIC_NUMBER,
+						   strnlen(CSTORE_MAGIC_NUMBER, NAMEDATALEN));
+	appendBinaryStringInfo(resultString, (char *) &majorVersion, sizeof(uint32));
+	appendBinaryStringInfo(resultString, (char *) &minorVersion, sizeof(uint32));
+	appendBinaryStringInfo(resultString, (char *)  &startingPage, sizeof(uint32));
+	appendBinaryStringInfo(resultString, (char *)  &pageCount, sizeof(uint32));
+
+	return resultString;
 }

--- a/cstore_metadata_serialization.h
+++ b/cstore_metadata_serialization.h
@@ -37,6 +37,8 @@ extern StripeFooter * DeserializeStripeFooter(StringInfo buffer);
 extern ColumnBlockSkipNode * DeserializeColumnSkipList(StringInfo buffer,
 													   bool typeByValue, int typeLength,
 													   uint32 blockCount);
-
+extern bool DeserializeTableFooterMetadata(const char *data, uint32 length,
+										   uint32 *startingPage, uint32 *pageCount);
+extern StringInfo SerializeTableFooterMetadata(uint32 startingPage, uint32 pageCount);
 
 #endif   /* CSTORE_SERIALIZATION_H */ 

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -34,7 +34,8 @@
 
 
 /* static function declarations */
-static StripeBuffers * LoadFilteredStripeBuffers(FILE *tableFile,
+static StringInfo ReadFooterData(Relation relation);
+static StripeBuffers * LoadFilteredStripeBuffers(Relation relation,
 												 StripeMetadata *stripeMetadata,
 												 TupleDesc tupleDescriptor,
 												 List *projectedColumnList,
@@ -43,14 +44,14 @@ static void ReadStripeNextRow(StripeBuffers *stripeBuffers, List *projectedColum
 							  uint64 blockIndex, uint64 blockRowIndex,
 							  ColumnBlockData **blockDataArray,
 							  Datum *columnValues, bool *columnNulls);
-static ColumnBuffers * LoadColumnBuffers(FILE *tableFile,
+static ColumnBuffers * LoadColumnBuffers(Relation relation,
 										 ColumnBlockSkipNode *blockSkipNodeArray,
 										 uint32 blockCount, uint64 existsFileOffset,
 										 uint64 valueFileOffset,
 										 Form_pg_attribute attributeForm);
-static StripeFooter * LoadStripeFooter(FILE *tableFile, StripeMetadata *stripeMetadata,
+static StripeFooter * LoadStripeFooter(Relation relation, StripeMetadata *stripeMetadata,
 									   uint32 columnCount);
-static StripeSkipList * LoadStripeSkipList(FILE *tableFile,
+static StripeSkipList * LoadStripeSkipList(Relation relation,
 										   StripeMetadata *stripeMetadata,
 										   StripeFooter *stripeFooter,
 										   uint32 columnCount,
@@ -78,11 +79,10 @@ static void DeserializeBlockData(StripeBuffers *stripeBuffers, uint64 blockIndex
 								 TupleDesc tupleDescriptor);
 static Datum ColumnDefaultValue(TupleConstr *tupleConstraints,
 								Form_pg_attribute attributeForm);
-static int64 FileSize(FILE *file);
-static StringInfo ReadFromFile(FILE *file, uint64 offset, uint32 size);
+static StringInfo ReadFromFile(Relation relation, uint64 offset, uint32 size);
 static void ResetUncompressedBlockData(ColumnBlockData **blockDataArray,
 									   uint32 columnCount);
-static uint64 StripeRowCount(FILE *tableFile, StripeMetadata *stripeMetadata);
+static uint64 StripeRowCount(Relation relation, StripeMetadata *stripeMetadata);
 
 
 /*
@@ -90,31 +90,21 @@ static uint64 StripeRowCount(FILE *tableFile, StripeMetadata *stripeMetadata);
  * read handle that's used during reading rows and finishing the read operation.
  */
 TableReadState *
-CStoreBeginRead(const char *filename, TupleDesc tupleDescriptor,
+CStoreBeginRead(Relation relation, TupleDesc tupleDescriptor,
 				List *projectedColumnList, List *whereClauseList)
 {
 	TableReadState *readState = NULL;
 	TableFooter *tableFooter = NULL;
-	FILE *tableFile = NULL;
 	MemoryContext stripeReadContext = NULL;
 	uint32 columnCount = 0;
 	bool *projectedColumnMask = NULL;
 	ColumnBlockData **blockDataArray  = NULL;
 
-	StringInfo tableFooterFilename = makeStringInfo();
-	appendStringInfo(tableFooterFilename, "%s%s", filename, CSTORE_FOOTER_FILE_SUFFIX);
+	tableFooter = CStoreReadFooter(relation);
 
-	tableFooter = CStoreReadFooter(tableFooterFilename);
-
-	pfree(tableFooterFilename->data);
-	pfree(tableFooterFilename);
-
-	tableFile = AllocateFile(filename, PG_BINARY_R);
-	if (tableFile == NULL)
+	if (tableFooter == NULL)
 	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not open file \"%s\" for reading: %m",
-							   filename)));
+		ereport(ERROR, (errmsg("Could not read table file.")));
 	}
 
 	/*
@@ -134,7 +124,6 @@ CStoreBeginRead(const char *filename, TupleDesc tupleDescriptor,
 										 	   tableFooter->blockRowCount);
 
 	readState = palloc0(sizeof(TableReadState));
-	readState->tableFile = tableFile;
 	readState->tableFooter = tableFooter;
 	readState->projectedColumnList = projectedColumnList;
 	readState->whereClauseList = whereClauseList;
@@ -145,78 +134,166 @@ CStoreBeginRead(const char *filename, TupleDesc tupleDescriptor,
 	readState->stripeReadContext = stripeReadContext;
 	readState->blockDataArray = blockDataArray;
 	readState->deserializedBlockIndex = -1;
+	readState->relation = relation;
 
 	return readState;
 }
 
 
 /*
- * CStoreReadFooter reads the cstore file footer from the given file. First, the
+ * CStoreReadFooter reads the cstore file footer for the given relation. First, the
  * function reads the last byte of the file as the postscript size. Then, the
  * function reads the postscript. Last, the function reads and deserializes the
  * footer.
+ *
+ * Footer data looks like following
+ * | table_footer (char[]) | postscript (char [postscriptSize]) | postscriptSize(uint8) |
+ * Parser first checks the last byte of the buffer to read postscript info that
+ * contains cstore major/minor version, cstore magic number, and byte length of
+ * the footer.
  */
 TableFooter *
-CStoreReadFooter(StringInfo tableFooterFilename)
+CStoreReadFooter(Relation relation)
 {
 	TableFooter *tableFooter = NULL;
-	FILE *tableFooterFile = NULL;
-	uint64 footerOffset = 0;
+	StringInfo footerData = NULL;
 	uint64 footerLength = 0;
 	StringInfo postscriptBuffer = NULL;
-	StringInfo postscriptSizeBuffer = NULL;
 	uint64 postscriptSizeOffset = 0;
 	uint8 postscriptSize = 0;
-	uint64 footerFileSize = 0;
 	uint64 postscriptOffset = 0;
-	StringInfo footerBuffer = NULL;
-	int freeResult = 0;
 
-	tableFooterFile = AllocateFile(tableFooterFilename->data, PG_BINARY_R);
-	if (tableFooterFile == NULL)
+	footerData = ReadFooterData(relation);
+	if (footerData == NULL)
 	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not open file \"%s\" for reading: %m",
-							   tableFooterFilename->data),
-						errhint("Try copying in data to the table.")));
+		return NULL;
 	}
 
-	footerFileSize = FileSize(tableFooterFile);
-	if (footerFileSize < CSTORE_POSTSCRIPT_SIZE_LENGTH)
-	{
-		ereport(ERROR, (errmsg("invalid cstore file")));
-	}
+	postscriptSizeOffset = footerData->len - CSTORE_POSTSCRIPT_SIZE_LENGTH;
+	memcpy(&postscriptSize, footerData->data + postscriptSizeOffset,
+		   CSTORE_POSTSCRIPT_SIZE_LENGTH);
 
-	postscriptSizeOffset = footerFileSize - CSTORE_POSTSCRIPT_SIZE_LENGTH;
-	postscriptSizeBuffer = ReadFromFile(tableFooterFile, postscriptSizeOffset,
-										CSTORE_POSTSCRIPT_SIZE_LENGTH);
-	memcpy(&postscriptSize, postscriptSizeBuffer->data, CSTORE_POSTSCRIPT_SIZE_LENGTH);
-	if (postscriptSize + CSTORE_POSTSCRIPT_SIZE_LENGTH > footerFileSize)
+	/* make sure data contains enough bytes to contain postscript */
+	if (postscriptSize + CSTORE_POSTSCRIPT_SIZE_LENGTH > footerData->len)
 	{
 		ereport(ERROR, (errmsg("invalid postscript size")));
 	}
 
-	postscriptOffset = footerFileSize - (CSTORE_POSTSCRIPT_SIZE_LENGTH + postscriptSize);
-	postscriptBuffer = ReadFromFile(tableFooterFile, postscriptOffset, postscriptSize);
+	postscriptOffset = postscriptSizeOffset - postscriptSize;
+
+	postscriptBuffer = makeStringInfo();
+	appendBinaryStringInfo(postscriptBuffer, footerData->data + postscriptOffset,
+						   postscriptSize);
 
 	DeserializePostScript(postscriptBuffer, &footerLength);
-	if (footerLength + postscriptSize + CSTORE_POSTSCRIPT_SIZE_LENGTH > footerFileSize)
+
+	/* make sure data contains enough bytes to contain whole footer */
+	if (footerLength + postscriptSize + CSTORE_POSTSCRIPT_SIZE_LENGTH != footerData->len)
 	{
 		ereport(ERROR, (errmsg("invalid footer size")));
 	}
 
-	footerOffset = postscriptOffset - footerLength;
-	footerBuffer = ReadFromFile(tableFooterFile, footerOffset, footerLength);
-	tableFooter = DeserializeTableFooter(footerBuffer);
+	/*
+	 * DeserializeTableFooter expects footer data without postscript, reduce len
+	 * field to trim the right end of footer data.
+	 */
+	footerData->len = footerLength;
+	tableFooter = DeserializeTableFooter(footerData);
 
-	freeResult = FreeFile(tableFooterFile);
-	if (freeResult != 0)
-	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not close file: %m")));
-	}
+	pfree(footerData->data);
+	pfree(footerData);
+
 
 	return tableFooter;
+}
+
+
+/*
+ * ReadFooterData reads and returns footer data. The first page contains the
+ * metadata about footer data. The function validates the metadata, reads
+ * footer data from where it is stored and returns it.
+ */
+static StringInfo ReadFooterData(Relation relation)
+{
+	int32 fileLength = 0;
+	BlockNumber totalBlockCount = 0;
+	BlockNumber blockIndex = 0;
+	const int headerLength = sizeof(int32);
+	StringInfo footerData = NULL;
+	Buffer firstBuffer = InvalidBuffer;
+	Page page = NULL;
+	char *pageData = NULL;
+	int pageDataLength = 0;
+	PageHeader pageHeader = NULL;
+	Buffer headerBuffer = InvalidBuffer;
+	Page headerPage = NULL;
+	char *headerData = NULL;
+	uint32 headerDataLength = 0;
+	uint32 startingBlock = 0;
+	uint32 blockCount = 0;
+
+	totalBlockCount = RelationGetNumberOfBlocksInFork(relation, FOOTER_FORKNUM);
+
+	if (totalBlockCount == 0)
+	{
+		return NULL;
+	}
+
+	headerBuffer =  ReadBufferExtended(relation, FOOTER_FORKNUM, 0, RBM_NORMAL,
+									   NULL);
+	LockBuffer(headerBuffer, BUFFER_LOCK_SHARE);
+	headerPage = BufferGetPage(headerBuffer);
+	headerData = PageGetContents(headerPage);
+	pageHeader = (PageHeader) headerPage;
+	headerDataLength =  pageHeader->pd_lower - SizeOfPageHeaderData;
+
+	if (!DeserializeTableFooterMetadata(headerData, headerDataLength,
+										&startingBlock, &blockCount))
+	{
+		UnlockReleaseBuffer(headerBuffer);
+		return NULL;
+	}
+
+	firstBuffer = ReadBufferExtended(relation, FOOTER_FORKNUM, startingBlock,
+									 RBM_NORMAL, NULL);
+
+	LockBuffer(firstBuffer, BUFFER_LOCK_SHARE);
+	page = BufferGetPage(firstBuffer);
+	pageHeader = (PageHeader) page;
+	pageData = PageGetContents(page);
+
+	memcpy(&fileLength, pageData, headerLength);
+
+	if (fileLength < CSTORE_POSTSCRIPT_SIZE_LENGTH)
+	{
+		ereport(ERROR, (errmsg("invalid cstore file")));
+	}
+
+	footerData = makeStringInfo();
+
+	pageDataLength = pageHeader->pd_lower - SizeOfPageHeaderData - headerLength;
+
+	appendBinaryStringInfo(footerData, pageData + headerLength, pageDataLength);
+
+	for (blockIndex = 1; blockIndex < blockCount; blockIndex++)
+	{
+		Buffer buffer = ReadBufferExtended(relation, FOOTER_FORKNUM,
+										   blockIndex + startingBlock,
+										   RBM_NORMAL, NULL);
+		LockBuffer(buffer, BUFFER_LOCK_SHARE);
+		page = BufferGetPage(buffer);
+		pageHeader = (PageHeader) page;
+		pageData = PageGetContents(page);
+		pageDataLength = pageHeader->pd_lower - SizeOfPageHeaderData;
+		appendBinaryStringInfo(footerData, pageData, pageDataLength);
+		LockBuffer(buffer, BUFFER_LOCK_UNLOCK);
+		ReleaseBuffer(buffer);
+	}
+
+	UnlockReleaseBuffer(firstBuffer);
+	UnlockReleaseBuffer(headerBuffer);
+
+	return footerData;
 }
 
 
@@ -257,7 +334,8 @@ CStoreReadNextRow(TableReadState *readState, Datum *columnValues, bool *columnNu
 		MemoryContextReset(readState->stripeReadContext);
 
 		stripeMetadata = list_nth(stripeMetadataList, readState->readStripeCount);
-		stripeBuffers = LoadFilteredStripeBuffers(readState->tableFile, stripeMetadata,
+
+		stripeBuffers = LoadFilteredStripeBuffers(readState->relation, stripeMetadata,
 												  readState->tupleDescriptor,
 												  readState->projectedColumnList,
 												  readState->whereClauseList);
@@ -332,7 +410,6 @@ CStoreEndRead(TableReadState *readState)
 	int columnCount = readState->tupleDescriptor->natts;
 
 	MemoryContextDelete(readState->stripeReadContext);
-	FreeFile(readState->tableFile);
 	list_free_deep(readState->tableFooter->stripeMetadataList);
 	FreeColumnBlockDataArray(readState->blockDataArray, columnCount);
 	pfree(readState->tableFooter);
@@ -395,36 +472,24 @@ FreeColumnBlockDataArray(ColumnBlockData **blockDataArray, uint32 columnCount)
 
 /* CStoreTableRowCount returns the exact row count of a table using skiplists */
 uint64
-CStoreTableRowCount(const char *filename)
+CStoreTableRowCount(Relation relation)
 {
 	TableFooter *tableFooter = NULL;
-	FILE *tableFile;
 	ListCell *stripeMetadataCell = NULL;
 	uint64 totalRowCount = 0;
 
-	StringInfo tableFooterFilename = makeStringInfo();
+	tableFooter = CStoreReadFooter(relation);
 
-	appendStringInfo(tableFooterFilename, "%s%s", filename, CSTORE_FOOTER_FILE_SUFFIX);
-
-	tableFooter = CStoreReadFooter(tableFooterFilename);
-
-	pfree(tableFooterFilename->data);
-	pfree(tableFooterFilename);
-
-	tableFile = AllocateFile(filename, PG_BINARY_R);
-	if (tableFile == NULL)
+	if (tableFooter == NULL)
 	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not open file \"%s\" for reading: %m", filename)));
+		ereport(ERROR, (errmsg("Could not read table file.")));
 	}
 
 	foreach(stripeMetadataCell, tableFooter->stripeMetadataList)
 	{
 		StripeMetadata *stripeMetadata = (StripeMetadata *) lfirst(stripeMetadataCell);
-		totalRowCount += StripeRowCount(tableFile, stripeMetadata);
+		totalRowCount += StripeRowCount(relation, stripeMetadata);
 	}
-
-	FreeFile(tableFile);
 
 	return totalRowCount;
 }
@@ -435,7 +500,7 @@ CStoreTableRowCount(const char *filename)
  * skip list, and returns number of rows for given stripe.
  */
 static uint64
-StripeRowCount(FILE *tableFile, StripeMetadata *stripeMetadata)
+StripeRowCount(Relation relation, StripeMetadata *stripeMetadata)
 {
 	uint64 rowCount = 0;
 	StripeFooter *stripeFooter = NULL;
@@ -447,10 +512,10 @@ StripeRowCount(FILE *tableFile, StripeMetadata *stripeMetadata)
 	footerOffset += stripeMetadata->skipListLength;
 	footerOffset += stripeMetadata->dataLength;
 
-	footerBuffer = ReadFromFile(tableFile, footerOffset, stripeMetadata->footerLength);
+	footerBuffer = ReadFromFile(relation, footerOffset, stripeMetadata->footerLength);
 	stripeFooter = DeserializeStripeFooter(footerBuffer);
 
-	firstColumnSkipListBuffer = ReadFromFile(tableFile, stripeMetadata->fileOffset,
+	firstColumnSkipListBuffer = ReadFromFile(relation, stripeMetadata->fileOffset,
 	                                         stripeFooter->skipListSizeArray[0]);
 	rowCount =  DeserializeRowCount(firstColumnSkipListBuffer);
 
@@ -459,12 +524,12 @@ StripeRowCount(FILE *tableFile, StripeMetadata *stripeMetadata)
 
 
 /*
- * LoadFilteredStripeBuffers reads serialized stripe data from the given file.
+ * LoadFilteredStripeBuffers reads serialized stripe data for given relation.
  * The function skips over blocks whose rows are refuted by restriction qualifiers,
  * and only loads columns that are projected in the query.
  */
 static StripeBuffers *
-LoadFilteredStripeBuffers(FILE *tableFile, StripeMetadata *stripeMetadata,
+LoadFilteredStripeBuffers(Relation relation, StripeMetadata *stripeMetadata,
 						  TupleDesc tupleDescriptor, List *projectedColumnList,
 						  List *whereClauseList)
 {
@@ -475,9 +540,9 @@ LoadFilteredStripeBuffers(FILE *tableFile, StripeMetadata *stripeMetadata,
 	Form_pg_attribute *attributeFormArray = tupleDescriptor->attrs;
 	uint32 columnCount = tupleDescriptor->natts;
 
-	StripeFooter *stripeFooter = LoadStripeFooter(tableFile, stripeMetadata,
+	StripeFooter *stripeFooter = LoadStripeFooter(relation, stripeMetadata,
 												  columnCount);
-	StripeSkipList *stripeSkipList = LoadStripeSkipList(tableFile, stripeMetadata,
+	StripeSkipList *stripeSkipList = LoadStripeSkipList(relation, stripeMetadata,
 														stripeFooter, columnCount,
 														attributeFormArray);
 
@@ -506,7 +571,7 @@ LoadFilteredStripeBuffers(FILE *tableFile, StripeMetadata *stripeMetadata,
 			Form_pg_attribute attributeForm = attributeFormArray[columnIndex];
 			uint32 blockCount = selectedBlockSkipList->blockCount;
 
-			ColumnBuffers *columnBuffers = LoadColumnBuffers(tableFile, blockSkipNode,
+			ColumnBuffers *columnBuffers = LoadColumnBuffers(relation, blockSkipNode,
 															 blockCount,
 															 existsFileOffset,
 															 valueFileOffset,
@@ -560,12 +625,12 @@ ReadStripeNextRow(StripeBuffers *stripeBuffers, List *projectedColumnList,
 
 
 /*
- * LoadColumnBuffers reads serialized column data from the given file. These
+ * LoadColumnBuffers reads serialized column data for given relation. These
  * column data are laid out as sequential blocks in the file; and block positions
  * and lengths are retrieved from the column block skip node array.
  */
 static ColumnBuffers *
-LoadColumnBuffers(FILE *tableFile, ColumnBlockSkipNode *blockSkipNodeArray,
+LoadColumnBuffers(Relation relation, ColumnBlockSkipNode *blockSkipNodeArray,
 				  uint32 blockCount, uint64 existsFileOffset, uint64 valueFileOffset,
 				  Form_pg_attribute attributeForm)
 {
@@ -588,7 +653,7 @@ LoadColumnBuffers(FILE *tableFile, ColumnBlockSkipNode *blockSkipNodeArray,
 	{
 		ColumnBlockSkipNode *blockSkipNode = &blockSkipNodeArray[blockIndex];
 		uint64 existsOffset = existsFileOffset + blockSkipNode->existsBlockOffset;
-		StringInfo rawExistsBuffer = ReadFromFile(tableFile, existsOffset,
+		StringInfo rawExistsBuffer = ReadFromFile(relation, existsOffset,
 												  blockSkipNode->existsLength);
 
 		blockBuffersArray[blockIndex]->existsBuffer = rawExistsBuffer;
@@ -600,7 +665,7 @@ LoadColumnBuffers(FILE *tableFile, ColumnBlockSkipNode *blockSkipNodeArray,
 		ColumnBlockSkipNode *blockSkipNode = &blockSkipNodeArray[blockIndex];
 		CompressionType compressionType = blockSkipNode->valueCompressionType;
 		uint64 valueOffset = valueFileOffset + blockSkipNode->valueBlockOffset;
-		StringInfo rawValueBuffer = ReadFromFile(tableFile, valueOffset,
+		StringInfo rawValueBuffer = ReadFromFile(relation, valueOffset,
 												 blockSkipNode->valueLength);
 
 		blockBuffersArray[blockIndex]->valueBuffer = rawValueBuffer;
@@ -616,7 +681,7 @@ LoadColumnBuffers(FILE *tableFile, ColumnBlockSkipNode *blockSkipNodeArray,
 
 /* Reads and returns the given stripe's footer. */
 static StripeFooter *
-LoadStripeFooter(FILE *tableFile, StripeMetadata *stripeMetadata,
+LoadStripeFooter(Relation relation, StripeMetadata *stripeMetadata,
 				 uint32 columnCount)
 {
 	StripeFooter *stripeFooter = NULL;
@@ -627,7 +692,7 @@ LoadStripeFooter(FILE *tableFile, StripeMetadata *stripeMetadata,
 	footerOffset += stripeMetadata->skipListLength;
 	footerOffset += stripeMetadata->dataLength;
 
-	footerBuffer = ReadFromFile(tableFile, footerOffset, stripeMetadata->footerLength);
+	footerBuffer = ReadFromFile(relation, footerOffset, stripeMetadata->footerLength);
 	stripeFooter = DeserializeStripeFooter(footerBuffer);
 	if (stripeFooter->columnCount > columnCount)
 	{
@@ -641,7 +706,7 @@ LoadStripeFooter(FILE *tableFile, StripeMetadata *stripeMetadata,
 
 /* Reads the skip list for the given stripe. */
 static StripeSkipList *
-LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
+LoadStripeSkipList(Relation relation, StripeMetadata *stripeMetadata,
 				   StripeFooter *stripeFooter, uint32 columnCount,
 				   Form_pg_attribute *attributeFormArray)
 {
@@ -654,7 +719,7 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 	uint32 stripeColumnCount = stripeFooter->columnCount;
 
 	/* deserialize block count */
-	firstColumnSkipListBuffer = ReadFromFile(tableFile, stripeMetadata->fileOffset,
+	firstColumnSkipListBuffer = ReadFromFile(relation, stripeMetadata->fileOffset,
 											 stripeFooter->skipListSizeArray[0]);
 	stripeBlockCount = DeserializeBlockCount(firstColumnSkipListBuffer);
 
@@ -668,7 +733,7 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 		Form_pg_attribute attributeForm = attributeFormArray[columnIndex];
 
 		StringInfo columnSkipListBuffer =
-			ReadFromFile(tableFile, currentColumnSkipListFileOffset, columnSkipListSize);
+			ReadFromFile(relation, currentColumnSkipListFileOffset, columnSkipListSize);
 
 		ColumnBlockSkipNode *columnSkipList =
 			DeserializeColumnSkipList(columnSkipListBuffer, attributeForm->attbyval,
@@ -1251,74 +1316,76 @@ ColumnDefaultValue(TupleConstr *tupleConstraints, Form_pg_attribute attributeFor
 }
 
 
-/* Returns the size of the given file handle. */
-static int64
-FileSize(FILE *file)
-{
-	int64 fileSize = 0;
-	int fseekResult = 0;
-
-	errno = 0;
-	fseekResult = fseeko(file, 0, SEEK_END);
-	if (fseekResult != 0)
-	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek in file: %m")));
-	}
-
-	fileSize = ftello(file);
-	if (fileSize == -1)
-	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not get position in file: %m")));
-	}
-
-	return fileSize;
-}
-
-
-/* Reads the given segment from the given file. */
+/* ReadFromFile reads the given segment from the relation data file. */
 static StringInfo
-ReadFromFile(FILE *file, uint64 offset, uint32 size)
+ReadFromFile(Relation relation, uint64 offset, uint32 size)
 {
-	int fseekResult = 0;
-	int freadResult = 0;
-	int fileError = 0;
-
-	StringInfo resultBuffer = makeStringInfo();
-	enlargeStringInfo(resultBuffer, size);
-	resultBuffer->len = size;
+	int blockCapacity = CSTORE_PAGE_DATA_SIZE;
+	uint32 blockNumber = offset / blockCapacity;
+	uint32 blockOffset = offset % blockCapacity;
+	uint32 remainingSize = size;
+	uint32 resultOffset = 0;
+	uint32 blockCount = 0;
+	StringInfo resultBuffer = NULL;
 
 	if (size == 0)
 	{
 		return resultBuffer;
 	}
 
-	errno = 0;
-	fseekResult = fseeko(file, offset, SEEK_SET);
-	if (fseekResult != 0)
+	resultBuffer = makeStringInfo();
+	enlargeStringInfo(resultBuffer, size);
+
+	blockCount = RelationGetNumberOfBlocksInFork(relation,DATA_FORKNUM);
+	if (blockNumber > blockCount)
 	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not seek in file: %m")));
+		ereport(ERROR, (errmsg("could not read from file")));
 	}
 
-	freadResult = fread(resultBuffer->data, size, 1, file);
-	if (freadResult != 1)
+	while (remainingSize > 0)
 	{
-		ereport(ERROR, (errmsg("could not read enough data from file")));
-	}
+		Buffer buffer = ReadBufferExtended(relation, DATA_FORKNUM, blockNumber,
+										   RBM_NORMAL, NULL);
+		Page page = NULL;
+		Size pageSize = 0;
+		char *pageContents = NULL;
+		PageHeader pageHeader = NULL;
 
-	fileError = ferror(file);
-	if (fileError != 0)
-	{
-		ereport(ERROR, (errcode_for_file_access(),
-						errmsg("could not read file: %m")));
+		if (buffer == InvalidBuffer)
+		{
+			ereport(ERROR, (errmsg("could not read enough data from file")));
+		}
+
+		LockBuffer(buffer, BUFFER_LOCK_SHARE);
+		page = BufferGetPage(buffer);
+		pageHeader = (PageHeader ) page;
+		pageSize = PageGetPageSize(page);
+		pageContents = PageGetContents(page);
+		uint32 bufferSize = pageHeader->pd_lower - SizeOfPageHeaderData;
+		uint32 copySize = remainingSize;
+
+		if (copySize > (bufferSize - blockOffset))
+		{
+			copySize = bufferSize - blockOffset;
+		}
+
+		appendBinaryStringInfo(resultBuffer, pageContents + blockOffset, copySize);
+		remainingSize -= copySize;
+
+		UnlockReleaseBuffer(buffer);
+
+		if (remainingSize == 0)
+		{
+			break;
+		}
+
+		blockNumber++;
+		blockOffset = 0;
+		resultOffset += copySize;
 	}
 
 	return resultBuffer;
 }
-
-
 
 
 /*

--- a/expected/create.out
+++ b/expected/create.out
@@ -7,34 +7,40 @@ CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
 -- Validator tests
 CREATE FOREIGN TABLE test_validator_invalid_option () 
 	SERVER cstore_server 
-	OPTIONS(filename 'data.cstore', bad_option_name '1'); -- ERROR
+	OPTIONS(bad_option_name '1'); -- ERROR
 ERROR:  invalid option "bad_option_name"
-HINT:  Valid options in this context are: filename, compression, stripe_row_count, block_row_count
+HINT:  Valid options in this context are: compression, stripe_row_count, block_row_count, logging
 CREATE FOREIGN TABLE test_validator_invalid_stripe_row_count () 
 	SERVER cstore_server
-	OPTIONS(filename 'data.cstore', stripe_row_count '0'); -- ERROR
+	OPTIONS(stripe_row_count '0'); -- ERROR
 ERROR:  invalid stripe row count
 HINT:  Stripe row count must be an integer between 1000 and 10000000
 CREATE FOREIGN TABLE test_validator_invalid_block_row_count () 
 	SERVER cstore_server
-	OPTIONS(filename 'data.cstore', block_row_count '0'); -- ERROR
+	OPTIONS(block_row_count '0'); -- ERROR
 ERROR:  invalid block row count
 HINT:  Block row count must be an integer between 1000 and 100000
 CREATE FOREIGN TABLE test_validator_invalid_compression_type () 
 	SERVER cstore_server
 	OPTIONS(filename 'data.cstore', compression 'invalid_compression'); -- ERROR
-ERROR:  invalid compression type
-HINT:  Valid options are: none, pglz
--- Invalid file path test
+ERROR:  invalid option "filename"
+HINT:  Valid options in this context are: compression, stripe_row_count, block_row_count, logging
+-- filename option is not supported anymore
 CREATE FOREIGN TABLE test_invalid_file_path ()
 	SERVER cstore_server
-	OPTIONS(filename 'bad_directory_path/bad_file_path'); --ERROR
-ERROR:  could not open file "bad_directory_path/bad_file_path" for writing: No such file or directory
+	OPTIONS(filename 'data.cstore'); --ERROR
+ERROR:  invalid option "filename"
+HINT:  Valid options in this context are: compression, stripe_row_count, block_row_count, logging
+-- valid logging options are true, and false
+CREATE FOREIGN TABLE test_invalid_log_option ()
+	SERVER cstore_server
+	OPTIONS(logging 'enabled'); --ERROR
+ERROR:  invalid logging flag
+HINT:  Valid options are: true, false
 -- Create uncompressed table
 CREATE FOREIGN TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
-	SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/contestant.cstore');
+	SERVER cstore_server;
 -- Create compressed table with automatically determined file path
 CREATE FOREIGN TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])

--- a/expected/drop.out
+++ b/expected/drop.out
@@ -1,33 +1,43 @@
 --
 -- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
 --
--- Check that files for the automatically managed table exist in the
--- cstore_fdw/{databaseoid} directory.
-SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
- count 
--------
-     2
-(1 row)
-
+-- determine base directory where tables files are created
+SELECT ('base/' || databaseoid)::text as databasedir
+	FROM (
+		SELECT oid::text databaseoid
+			FROM pg_database
+			WHERE datname = current_database()) pgdir
+	\gset
+-- record created cstore relation oids as text
+SELECT array_agg(relation_name::regclass::oid::text) as relation_oids
+	FROM (
+		SELECT unnest(ARRAY[
+			'contestant',
+			'contestant_compressed']) relation_name) l
+	\gset
 -- DROP cstore_fdw tables
 DROP FOREIGN TABLE contestant;
 DROP FOREIGN TABLE contestant_compressed;
 -- Create a cstore_fdw table under a schema and drop it.
 CREATE SCHEMA test_schema;
 CREATE FOREIGN TABLE test_schema.test_table(data int) SERVER cstore_server;
+-- append this relation's oid to relation_oids
+SELECT :'relation_oids'::text[] || relation_oid as relation_oids
+	FROM (
+		SELECT 'test_schema.test_table'::regclass::oid::text as relation_oid) q1
+	\gset
 DROP SCHEMA test_schema CASCADE;
 NOTICE:  drop cascades to foreign table test_schema.test_table
--- Check that the files have been deleted and the directory is empty after the
--- DROP table command.
+-- Check that the files have been deleted from databasedir
+-- note that postgres maintaines 1 file per relation even
+-- after the relation is dropped. 0 sized file is removed
+-- during checkpoint
 SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;
  count 
 -------
-     0
+     3
 (1 row)
 

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -1,22 +1,27 @@
 --
 -- Test the TRUNCATE TABLE command for cstore_fdw tables.
 --
--- Check that files for the automatically managed table exist in the
--- cstore_fdw/{databaseoid} directory.
-SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
- count 
--------
-     0
-(1 row)
-
 -- CREATE a cstore_fdw table, fill with some data --
 CREATE FOREIGN TABLE cstore_truncate_test (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_second (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_compressed (a int, b int) SERVER cstore_server OPTIONS (compression 'pglz');
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
+-- record created cstore relation oids as text
+SELECT array_agg(relation_name::regclass::oid::text) as relation_oids
+	FROM (
+		SELECT unnest(ARRAY[
+			'cstore_truncate_test',
+			'cstore_truncate_test_second',
+			'cstore_truncate_test_compressed']) relation_name) l
+	\gset
+-- determine base directory where tables files are created
+SELECT ('base/' || databaseoid)::text as databasedir
+	FROM (
+		SELECT oid::text databaseoid
+			FROM pg_database
+			WHERE datname = current_database()) pgdir
+	\gset
+	
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
@@ -64,14 +69,14 @@ SELECT count(*) FROM cstore_truncate_test_compressed;
 SELECT cstore_table_size('cstore_truncate_test_compressed');
  cstore_table_size 
 -------------------
-                26
+             16384
 (1 row)
 
--- make sure data files still present 
+-- make sure data files still present (expect total 4 files 2 per relation)
 SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;
  count 
 -------
      6
@@ -146,6 +151,11 @@ SELECT * from cstore_truncate_test_regular;
 ---+---
 (0 rows)
 
+SELECT * from cstore_truncate_test_compressed;
+ a | b 
+---+---
+(0 rows)
+
 -- test if truncate on empty table works
 TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
@@ -153,6 +163,16 @@ SELECT * from cstore_truncate_test;
 ---+---
 (0 rows)
 
-DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
+DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second, cstore_truncate_test_compressed;
 DROP TABLE cstore_truncate_test_regular;
-DROP FOREIGN TABLE cstore_truncate_test_compressed;
+-- make sure data files are removed
+-- 1 file per relation is kept by postgresql
+SELECT count(*) FROM (
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;
+ count 
+-------
+     3
+(1 row)
+

--- a/input/block_filtering.source
+++ b/input/block_filtering.source
@@ -30,8 +30,7 @@ $$ LANGUAGE PLPGSQL;
 -- Create and load data
 CREATE FOREIGN TABLE test_block_filtering (a int)
     SERVER cstore_server
-    OPTIONS(filename '@abs_srcdir@/data/block_filtering.cstore',
-            block_row_count '1000', stripe_row_count '2000');
+    OPTIONS(block_row_count '1000', stripe_row_count '2000');
 
 COPY test_block_filtering FROM '@abs_srcdir@/data/block_filtering.csv' WITH CSV;
 
@@ -60,8 +59,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_block_filtering WHERE a BET
 
 -- Verify that we are fine with collations which use a different alphabet order
 CREATE FOREIGN TABLE collation_block_filtering_test(A text collate "da_DK")
-    SERVER cstore_server
-    OPTIONS(filename '@abs_srcdir@/data/collation_block_filtering.cstore');
+    SERVER cstore_server;
 COPY collation_block_filtering_test FROM STDIN;
 A
 Å

--- a/input/copyto.source
+++ b/input/copyto.source
@@ -3,8 +3,7 @@
 --
 CREATE FOREIGN TABLE test_contestant(handle TEXT, birthdate DATE, rating INT,
         percentile FLOAT, country CHAR(3), achievements TEXT[])
-        SERVER cstore_server
-        OPTIONS(filename '@abs_srcdir@/data/test_contestant.cstore');
+        SERVER cstore_server;
 
 -- load table data from file
 COPY test_contestant FROM '@abs_srcdir@/data/contestants.1.csv' WITH CSV;

--- a/input/data_types.source
+++ b/input/data_types.source
@@ -11,8 +11,7 @@ SET intervalstyle TO 'POSTGRES_VERBOSE';
 
 -- Test array types
 CREATE FOREIGN TABLE test_array_types (int_array int[], bigint_array bigint[],
-	text_array text[]) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/array_types.cstore');
+	text_array text[]) SERVER cstore_server;
 
 COPY test_array_types FROM '@abs_srcdir@/data/array_types.csv' WITH CSV;
 
@@ -22,8 +21,7 @@ SELECT * FROM test_array_types;
 -- Test date/time types
 CREATE FOREIGN TABLE test_datetime_types (timestamp timestamp,
 	timestamp_with_timezone timestamp with time zone, date date, time time,
-	interval interval) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/datetime_types.cstore');
+	interval interval) SERVER cstore_server;
 
 COPY test_datetime_types FROM '@abs_srcdir@/data/datetime_types.csv' WITH CSV;
 
@@ -35,8 +33,7 @@ CREATE TYPE enum_type AS ENUM ('a', 'b', 'c');
 CREATE TYPE composite_type AS (a int, b text);
 
 CREATE FOREIGN TABLE test_enum_and_composite_types (enum enum_type,
-	composite composite_type) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/enum_and_composite_types.cstore');
+	composite composite_type) SERVER cstore_server;
 
 COPY test_enum_and_composite_types FROM
 	'@abs_srcdir@/data/enum_and_composite_types.csv' WITH CSV;
@@ -46,8 +43,7 @@ SELECT * FROM test_enum_and_composite_types;
 
 -- Test range types
 CREATE FOREIGN TABLE test_range_types (int4range int4range, int8range int8range,
-	numrange numrange, tsrange tsrange) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/range_types.cstore');
+	numrange numrange, tsrange tsrange) SERVER cstore_server;
 
 COPY test_range_types FROM '@abs_srcdir@/data/range_types.csv' WITH CSV;
 
@@ -56,8 +52,7 @@ SELECT * FROM test_range_types;
 
 -- Test other types
 CREATE FOREIGN TABLE test_other_types (bool boolean, bytea bytea, money money,
-	inet inet, bitstring bit varying(5), uuid uuid, json json) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/other_types.cstore');
+	inet inet, bitstring bit varying(5), uuid uuid, json json) SERVER cstore_server;
 
 COPY test_other_types FROM '@abs_srcdir@/data/other_types.csv' WITH CSV;
 
@@ -66,8 +61,7 @@ SELECT * FROM test_other_types;
 
 -- Test null values
 CREATE FOREIGN TABLE test_null_values (a int, b int[], c composite_type)
-	SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/null_values.cstore');
+	SERVER cstore_server;
 
 COPY test_null_values FROM '@abs_srcdir@/data/null_values.csv' WITH CSV;
 

--- a/output/block_filtering.source
+++ b/output/block_filtering.source
@@ -26,8 +26,7 @@ $$ LANGUAGE PLPGSQL;
 -- Create and load data
 CREATE FOREIGN TABLE test_block_filtering (a int)
     SERVER cstore_server
-    OPTIONS(filename '@abs_srcdir@/data/block_filtering.cstore',
-            block_row_count '1000', stripe_row_count '2000');
+    OPTIONS(block_row_count '1000', stripe_row_count '2000');
 COPY test_block_filtering FROM '@abs_srcdir@/data/block_filtering.csv' WITH CSV;
 -- Verify that filtered_row_count is less than 1000 for the following queries
 SELECT filtered_row_count('SELECT count(*) FROM test_block_filtering');
@@ -107,8 +106,7 @@ SELECT filtered_row_count('SELECT count(*) FROM test_block_filtering WHERE a BET
 
 -- Verify that we are fine with collations which use a different alphabet order
 CREATE FOREIGN TABLE collation_block_filtering_test(A text collate "da_DK")
-    SERVER cstore_server
-    OPTIONS(filename '@abs_srcdir@/data/collation_block_filtering.cstore');
+    SERVER cstore_server;
 COPY collation_block_filtering_test FROM STDIN;
 SELECT * FROM collation_block_filtering_test WHERE A > 'B';
  a 

--- a/output/copyto.source
+++ b/output/copyto.source
@@ -3,8 +3,7 @@
 --
 CREATE FOREIGN TABLE test_contestant(handle TEXT, birthdate DATE, rating INT,
         percentile FLOAT, country CHAR(3), achievements TEXT[])
-        SERVER cstore_server
-        OPTIONS(filename '@abs_srcdir@/data/test_contestant.cstore');
+        SERVER cstore_server;
 -- load table data from file
 COPY test_contestant FROM '@abs_srcdir@/data/contestants.1.csv' WITH CSV;
 -- export using COPY table TO ...

--- a/output/data_types.source
+++ b/output/data_types.source
@@ -7,8 +7,7 @@ SET timezone to 'GMT';
 SET intervalstyle TO 'POSTGRES_VERBOSE';
 -- Test array types
 CREATE FOREIGN TABLE test_array_types (int_array int[], bigint_array bigint[],
-	text_array text[]) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/array_types.cstore');
+	text_array text[]) SERVER cstore_server;
 COPY test_array_types FROM '@abs_srcdir@/data/array_types.csv' WITH CSV;
 SELECT * FROM test_array_types;
         int_array         |                bigint_array                | text_array 
@@ -21,8 +20,7 @@ SELECT * FROM test_array_types;
 -- Test date/time types
 CREATE FOREIGN TABLE test_datetime_types (timestamp timestamp,
 	timestamp_with_timezone timestamp with time zone, date date, time time,
-	interval interval) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/datetime_types.cstore');
+	interval interval) SERVER cstore_server;
 COPY test_datetime_types FROM '@abs_srcdir@/data/datetime_types.csv' WITH CSV;
 SELECT * FROM test_datetime_types;
       timestamp      | timestamp_with_timezone |    date    |   time   | interval  
@@ -35,8 +33,7 @@ SELECT * FROM test_datetime_types;
 CREATE TYPE enum_type AS ENUM ('a', 'b', 'c');
 CREATE TYPE composite_type AS (a int, b text);
 CREATE FOREIGN TABLE test_enum_and_composite_types (enum enum_type,
-	composite composite_type) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/enum_and_composite_types.cstore');
+	composite composite_type) SERVER cstore_server;
 COPY test_enum_and_composite_types FROM
 	'@abs_srcdir@/data/enum_and_composite_types.csv' WITH CSV;
 SELECT * FROM test_enum_and_composite_types;
@@ -48,8 +45,7 @@ SELECT * FROM test_enum_and_composite_types;
 
 -- Test range types
 CREATE FOREIGN TABLE test_range_types (int4range int4range, int8range int8range,
-	numrange numrange, tsrange tsrange) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/range_types.cstore');
+	numrange numrange, tsrange tsrange) SERVER cstore_server;
 COPY test_range_types FROM '@abs_srcdir@/data/range_types.csv' WITH CSV;
 SELECT * FROM test_range_types;
  int4range | int8range | numrange |                    tsrange                    
@@ -60,8 +56,7 @@ SELECT * FROM test_range_types;
 
 -- Test other types
 CREATE FOREIGN TABLE test_other_types (bool boolean, bytea bytea, money money,
-	inet inet, bitstring bit varying(5), uuid uuid, json json) SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/other_types.cstore');
+	inet inet, bitstring bit varying(5), uuid uuid, json json) SERVER cstore_server;
 COPY test_other_types FROM '@abs_srcdir@/data/other_types.csv' WITH CSV;
 SELECT * FROM test_other_types;
  bool |   bytea    | money |    inet     | bitstring |                 uuid                 |       json       
@@ -72,8 +67,7 @@ SELECT * FROM test_other_types;
 
 -- Test null values
 CREATE FOREIGN TABLE test_null_values (a int, b int[], c composite_type)
-	SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/null_values.cstore');
+	SERVER cstore_server;
 COPY test_null_values FROM '@abs_srcdir@/data/null_values.csv' WITH CSV;
 SELECT * FROM test_null_values;
  a |   b    |  c  

--- a/sql/create.sql
+++ b/sql/create.sql
@@ -12,31 +12,34 @@ CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
 -- Validator tests
 CREATE FOREIGN TABLE test_validator_invalid_option () 
 	SERVER cstore_server 
-	OPTIONS(filename 'data.cstore', bad_option_name '1'); -- ERROR
+	OPTIONS(bad_option_name '1'); -- ERROR
 
 CREATE FOREIGN TABLE test_validator_invalid_stripe_row_count () 
 	SERVER cstore_server
-	OPTIONS(filename 'data.cstore', stripe_row_count '0'); -- ERROR
+	OPTIONS(stripe_row_count '0'); -- ERROR
 
 CREATE FOREIGN TABLE test_validator_invalid_block_row_count () 
 	SERVER cstore_server
-	OPTIONS(filename 'data.cstore', block_row_count '0'); -- ERROR
+	OPTIONS(block_row_count '0'); -- ERROR
 
 CREATE FOREIGN TABLE test_validator_invalid_compression_type () 
 	SERVER cstore_server
 	OPTIONS(filename 'data.cstore', compression 'invalid_compression'); -- ERROR
 
--- Invalid file path test
+-- filename option is not supported anymore
 CREATE FOREIGN TABLE test_invalid_file_path ()
 	SERVER cstore_server
-	OPTIONS(filename 'bad_directory_path/bad_file_path'); --ERROR
+	OPTIONS(filename 'data.cstore'); --ERROR
+
+-- valid logging options are true, and false
+CREATE FOREIGN TABLE test_invalid_log_option ()
+	SERVER cstore_server
+	OPTIONS(logging 'enabled'); --ERROR
 
 -- Create uncompressed table
 CREATE FOREIGN TABLE contestant (handle TEXT, birthdate DATE, rating INT,
 	percentile FLOAT, country CHAR(3), achievements TEXT[])
-	SERVER cstore_server
-	OPTIONS(filename '@abs_srcdir@/data/contestant.cstore');
-
+	SERVER cstore_server;
 
 -- Create compressed table with automatically determined file path
 CREATE FOREIGN TABLE contestant_compressed (handle TEXT, birthdate DATE, rating INT,

--- a/sql/drop.sql
+++ b/sql/drop.sql
@@ -2,12 +2,21 @@
 -- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
 --
 
--- Check that files for the automatically managed table exist in the
--- cstore_fdw/{databaseoid} directory.
-SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
+-- determine base directory where tables files are created
+SELECT ('base/' || databaseoid)::text as databasedir
+	FROM (
+		SELECT oid::text databaseoid
+			FROM pg_database
+			WHERE datname = current_database()) pgdir
+	\gset
+
+-- record created cstore relation oids as text
+SELECT array_agg(relation_name::regclass::oid::text) as relation_oids
+	FROM (
+		SELECT unnest(ARRAY[
+			'contestant',
+			'contestant_compressed']) relation_name) l
+	\gset
 
 -- DROP cstore_fdw tables
 DROP FOREIGN TABLE contestant;
@@ -16,11 +25,18 @@ DROP FOREIGN TABLE contestant_compressed;
 -- Create a cstore_fdw table under a schema and drop it.
 CREATE SCHEMA test_schema;
 CREATE FOREIGN TABLE test_schema.test_table(data int) SERVER cstore_server;
+-- append this relation's oid to relation_oids
+SELECT :'relation_oids'::text[] || relation_oid as relation_oids
+	FROM (
+		SELECT 'test_schema.test_table'::regclass::oid::text as relation_oid) q1
+	\gset
 DROP SCHEMA test_schema CASCADE;
 
--- Check that the files have been deleted and the directory is empty after the
--- DROP table command.
+-- Check that the files have been deleted from databasedir
+-- note that postgres maintaines 1 file per relation even
+-- after the relation is dropped. 0 sized file is removed
+-- during checkpoint
 SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;

--- a/sql/truncate.sql
+++ b/sql/truncate.sql
@@ -2,19 +2,29 @@
 -- Test the TRUNCATE TABLE command for cstore_fdw tables.
 --
 
--- Check that files for the automatically managed table exist in the
--- cstore_fdw/{databaseoid} directory.
-SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
-
 -- CREATE a cstore_fdw table, fill with some data --
 CREATE FOREIGN TABLE cstore_truncate_test (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_second (a int, b int) SERVER cstore_server;
 CREATE FOREIGN TABLE cstore_truncate_test_compressed (a int, b int) SERVER cstore_server OPTIONS (compression 'pglz');
 CREATE TABLE cstore_truncate_test_regular (a int, b int);
 
+-- record created cstore relation oids as text
+SELECT array_agg(relation_name::regclass::oid::text) as relation_oids
+	FROM (
+		SELECT unnest(ARRAY[
+			'cstore_truncate_test',
+			'cstore_truncate_test_second',
+			'cstore_truncate_test_compressed']) relation_name) l
+	\gset
+
+-- determine base directory where tables files are created
+SELECT ('base/' || databaseoid)::text as databasedir
+	FROM (
+		SELECT oid::text databaseoid
+			FROM pg_database
+			WHERE datname = current_database()) pgdir
+	\gset
+	
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 
 INSERT INTO cstore_truncate_test_compressed select a, a from generate_series(1, 10) a;
@@ -28,18 +38,16 @@ TRUNCATE TABLE cstore_truncate_test;
 SELECT * FROM cstore_truncate_test;
 
 SELECT COUNT(*) from cstore_truncate_test;
-
 SELECT count(*) FROM cstore_truncate_test_compressed;
 TRUNCATE TABLE cstore_truncate_test_compressed;
 SELECT count(*) FROM cstore_truncate_test_compressed;
-
 SELECT cstore_table_size('cstore_truncate_test_compressed');
 
--- make sure data files still present 
+-- make sure data files still present (expect total 4 files 2 per relation)
 SELECT count(*) FROM (
-	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
-	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
-	) AS q1) AS q2;
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;
 
 INSERT INTO cstore_truncate_test select a, a from generate_series(1, 10) a;
 INSERT INTO cstore_truncate_test_regular select a, a from generate_series(10, 20) a;
@@ -59,11 +67,18 @@ TRUNCATE TABLE cstore_truncate_test,
 SELECT * from cstore_truncate_test;
 SELECT * from cstore_truncate_test_second;
 SELECT * from cstore_truncate_test_regular;
+SELECT * from cstore_truncate_test_compressed;
 
 -- test if truncate on empty table works
 TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
 
-DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
+DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second, cstore_truncate_test_compressed;
 DROP TABLE cstore_truncate_test_regular;
-DROP FOREIGN TABLE cstore_truncate_test_compressed;
+
+-- make sure data files are removed
+-- 1 file per relation is kept by postgresql
+SELECT count(*) FROM (
+	SELECT * FROM pg_ls_dir(:'databasedir') as file_name
+	WHERE (regexp_split_to_array(file_name, '_'))[1] IN 
+		(SELECT * FROM unnest(:'relation_oids'::text[])) ) q1;


### PR DESCRIPTION
We are going to use postgres storage instead of
regular files. This would be able to create
write logs which will enable replicating
cstore table contents via stream replication.

Filename option that enabled using arbitrary file
path is no longer valid. A new option 'logging' is
introduced to control loggin behavior. Its default
value is set to true meaning logging is enabled.