### PR TITLE
Fix incorrect initialization of columnSkipList for missing columns

### DIFF
--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -689,15 +689,15 @@ LoadStripeSkipList(FILE *tableFile, StripeMetadata *stripeMetadata,
 
 		for (blockIndex = 0; blockIndex < stripeBlockCount; blockIndex++)
 		{
-			columnSkipList->rowCount = 0;
-			columnSkipList->hasMinMax = false;
-			columnSkipList->minimumValue = 0;
-			columnSkipList->maximumValue = 0;
-			columnSkipList->existsBlockOffset = 0;
-			columnSkipList->valueBlockOffset = 0;
-			columnSkipList->existsLength = 0;
-			columnSkipList->valueLength = 0;
-			columnSkipList->valueCompressionType = COMPRESSION_NONE;
+			columnSkipList[blockIndex].rowCount = 0;
+			columnSkipList[blockIndex].hasMinMax = false;
+			columnSkipList[blockIndex].minimumValue = 0;
+			columnSkipList[blockIndex].maximumValue = 0;
+			columnSkipList[blockIndex].existsBlockOffset = 0;
+			columnSkipList[blockIndex].valueBlockOffset = 0;
+			columnSkipList[blockIndex].existsLength = 0;
+			columnSkipList[blockIndex].valueLength = 0;
+			columnSkipList[blockIndex].valueCompressionType = COMPRESSION_NONE;
 		}
 		blockSkipNodeArray[columnIndex] = columnSkipList;
 	}


### PR DESCRIPTION
Some columns to cstore table might be added after some data was ingested. This makes earlier stripes to not to have appropriate value for ColumnBlockSkipNode. Earlier work initialized them to be default values. However initialization code was faulty and did not initialize all blocks properly.

This issue was found by a user. 
Fixes #135 
