### PR TITLE
Enable cancelling copy in

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -493,6 +493,8 @@ CopyIntoCStoreTable(const CopyStmt *copyStatement, const char *queryString)
 		}
 
 		MemoryContextReset(tupleContext);
+
+		CHECK_FOR_INTERRUPTS();
 	}
 
 	/* end read/write sessions and close the relation */


### PR DESCRIPTION
Copy in loop calls ```CHECK_FOR_INTERRUPTS();``` after each row insert to enable cancelling. Some content is written to data file, but since footer is not updated they won't be visible.

One down side is that written content still takes space in disk until being overwritten by subsequent copy or insert calls.

Fixes #145 
