### PR TITLE
Directory creation and cleanup after database operations

### DIFF
--- a/expected/drop.out
+++ b/expected/drop.out
@@ -1,6 +1,17 @@
 --
--- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
+-- Tests the different DROP commands for cstore_fdw tables.
 --
+-- DROP FOREIGN TABL
+-- DROP SCHEMA
+-- DROP EXTENSION
+-- DROP DATABASE
+--
+-- Note that travis does not create
+-- cstore_fdw extension in default database (postgres). This has caused
+-- different behavior between travis tests and local tests. Thus
+-- 'postgres' directory is excluded from comparison to have the same result.
+-- store postgres database oid
+SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
 SELECT count(*) FROM (
@@ -29,5 +40,58 @@ SELECT count(*) FROM (
  count 
 -------
      0
+(1 row)
+
+SELECT current_database() datname \gset
+CREATE DATABASE db_to_drop;
+\c db_to_drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 files, data and footer file for single table
+SELECT count(*) FROM pg_ls_dir('cstore_fdw/' || :databaseoid);
+ count 
+-------
+     2
+(1 row)
+
+-- should see 2 directories 1 for each database, excluding postgres database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     2
+(1 row)
+
+DROP EXTENSION cstore_fdw CASCADE;
+NOTICE:  drop cascades to 2 other objects
+DETAIL:  drop cascades to server cstore_server
+drop cascades to foreign table test_table
+-- should only see 1 directory here
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     1
+(1 row)
+
+-- test database drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 directories 1 for each database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     2
+(1 row)
+
+\c :datname
+DROP DATABASE db_to_drop;
+-- should only see 1 directory for the default database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+ count 
+-------
+     1
 (1 row)
 

--- a/sql/drop.sql
+++ b/sql/drop.sql
@@ -1,6 +1,19 @@
 --
--- Test the DROP FOREIGN TABLE command for cstore_fdw tables.
+-- Tests the different DROP commands for cstore_fdw tables.
 --
+-- DROP FOREIGN TABL
+-- DROP SCHEMA
+-- DROP EXTENSION
+-- DROP DATABASE
+--
+
+-- Note that travis does not create
+-- cstore_fdw extension in default database (postgres). This has caused
+-- different behavior between travis tests and local tests. Thus
+-- 'postgres' directory is excluded from comparison to have the same result.
+
+-- store postgres database oid
+SELECT oid postgres_oid FROM pg_database WHERE datname = 'postgres' \gset
 
 -- Check that files for the automatically managed table exist in the
 -- cstore_fdw/{databaseoid} directory.
@@ -24,3 +37,40 @@ SELECT count(*) FROM (
 	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
 	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
 	) AS q1) AS q2;
+
+SELECT current_database() datname \gset
+
+CREATE DATABASE db_to_drop;
+\c db_to_drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+-- should see 2 files, data and footer file for single table
+SELECT count(*) FROM pg_ls_dir('cstore_fdw/' || :databaseoid);
+
+-- should see 2 directories 1 for each database, excluding postgres database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+DROP EXTENSION cstore_fdw CASCADE;
+
+-- should only see 1 directory here
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+-- test database drop
+CREATE EXTENSION cstore_fdw;
+CREATE SERVER cstore_server FOREIGN DATA WRAPPER cstore_fdw;
+SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database() \gset
+
+CREATE FOREIGN TABLE test_table(data int) SERVER cstore_server;
+
+-- should see 2 directories 1 for each database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;
+
+\c :datname
+
+DROP DATABASE db_to_drop;
+
+-- should only see 1 directory for the default database
+SELECT count(*) FROM pg_ls_dir('cstore_fdw') WHERE pg_ls_dir != :postgres_oid::text;


### PR DESCRIPTION
This PR addresses an issue when a foreign server is created inside a template database, newly created databases can not create foreign tables due to missing folder. This fix makes sure required directroy exists prior to creating files in it.

This also makes sure that cstore files are removed after a database or cstore extension is dropped out of current database.

There are 2 mishaps that we can't address
- if the cstore table is created with file name option, there is no way of removing it when a database/extension is dropped
- if the active database does not have cstore extension created, then we can't reclaim resources of the dropped database.


Fixes : #124 , #129 