### PR TITLE
Check if the user has truncate privilege on the table

### DIFF
--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -128,9 +128,11 @@ SELECT * from cstore_truncate_test_regular;
 (11 rows)
 
 -- make sure multi truncate works
-TRUNCATE TABLE cstore_truncate_test, 
+-- notice that the same table might be repeated
+TRUNCATE TABLE cstore_truncate_test,
 			   cstore_truncate_test_regular,
-			   cstore_truncate_test_second;
+			   cstore_truncate_test_second,
+   			   cstore_truncate_test;
 SELECT * from cstore_truncate_test;
  a | b 
 ---+---
@@ -156,3 +158,76 @@ SELECT * from cstore_truncate_test;
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;
+-- test truncate with schema
+CREATE SCHEMA truncate_schema;
+CREATE FOREIGN TABLE truncate_schema.truncate_tbl (id int) SERVER cstore_server OPTIONS(compression 'pglz');
+INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
+SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+SELECT COUNT(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
+
+INSERT INTO truncate_schema.truncate_tbl SELECT generate_series(1, 100);
+-- create a user that can not truncate
+CREATE USER truncate_user;
+GRANT USAGE ON SCHEMA truncate_schema TO truncate_user;
+GRANT SELECT ON TABLE truncate_schema.truncate_tbl TO truncate_user;
+REVOKE TRUNCATE ON TABLE truncate_schema.truncate_tbl FROM truncate_user;
+SELECT current_user \gset
+\c - truncate_user
+-- verify truncate command fails and check number of rows
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+ERROR:  permission denied for relation truncate_tbl
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+-- switch to super user, grant truncate to truncate_user 
+\c - :current_user
+GRANT TRUNCATE ON TABLE truncate_schema.truncate_tbl TO truncate_user;
+-- verify truncate_user can truncate now
+\c - truncate_user
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+   100
+(1 row)
+
+TRUNCATE TABLE truncate_schema.truncate_tbl;
+SELECT count(*) FROM truncate_schema.truncate_tbl;
+ count 
+-------
+     0
+(1 row)
+
+\c - :current_user
+-- cleanup
+DROP SCHEMA truncate_schema CASCADE;
+NOTICE:  drop cascades to foreign table truncate_schema.truncate_tbl
+DROP USER truncate_user;
+-- verify files are removed
+SELECT count(*) FROM (
+	SELECT pg_ls_dir('cstore_fdw/' || databaseoid ) FROM (
+	SELECT oid::text databaseoid FROM pg_database WHERE datname = current_database()
+	) AS q1) AS q2;
+ count 
+-------
+     0
+(1 row)
+


### PR DESCRIPTION
 We rely on postgres to do access control checks for all functions. However, since truncate for cstore tables is handled in process utility,  not forwarded to postgres, and we did not check if a user has truncate right on the table, we let unprivileged user to perform truncate.

This fix introduces acl check prior to truncating files, and reports error if user has failed the check.

Fixes #148 