### PR TITLE
Specify protobuf syntax version.

### DIFF
--- a/cstore.proto
+++ b/cstore.proto
@@ -1,3 +1,5 @@
+syntax = "proto2";
+
 package protobuf;
 
 enum CompressionType {


### PR DESCRIPTION
Without this, we get the following build warning: "No syntax specified for the proto file: cstore.proto. Please use 'syntax = "proto2";' or 'syntax = "proto3";' to specify a syntax version. (Defaulted to proto2 syntax.)".

