### PR TITLE
Check if folder exists before issuing delete command

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1133,7 +1133,10 @@ RemoveCStoreDatabaseDirectory(Oid databaseOid)
 	appendStringInfo(cstoreDatabaseDirectoryPath, "%s/%s/%u", DataDir,
 					 CSTORE_FDW_NAME, databaseOid);
 
-	rmtree(cstoreDatabaseDirectoryPath->data, true);
+	if (DirectoryExists(cstoreDatabaseDirectoryPath))
+	{
+		rmtree(cstoreDatabaseDirectoryPath->data, true);
+	}
 }
 
 


### PR DESCRIPTION
We are blindly running ```rmtree()``` command to remove a database folder under ``cstore_fdw``` folder. 

This PR introduces a check before actually deleting the folder.

Fixes #157  