### PR TITLE
fix a segfault when processing truncate in cached plans

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -368,11 +368,6 @@ CStoreProcessUtility(Node * parseTree, const char *queryString,
 
 			CALL_PREVIOUS_UTILITY((Node *) truncateStatement, queryString, context, paramListInfo,
 								  destReceiver, completionTag);
-                        /* restore the former relation list. Our
-                         * replacement could be freed but still needed
-                         * in a cached plan. A truncate can be cached
-                         * if run from a pl/pgSQL function */
-                        truncateStatement->relations = allTablesList;
 		}
 
 		TruncateCStoreTables(cstoreRelationList);

--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -360,6 +360,11 @@ CStoreProcessUtility(Node * parseTree, const char *queryString,
 
 			CALL_PREVIOUS_UTILITY(parseTree, queryString, context, paramListInfo,
 								  destReceiver, completionTag);
+                        /* restore the former relation list. Our
+                         * replacement could be freed but still needed
+                         * in a cached plan. A truncate can be cached
+                         * if run from a pl/pgSQL function */
+                        truncateStatement->relations = allTablesList;
 		}
 
 		TruncateCStoreTables(cstoreRelationList);

--- a/expected/truncate.out
+++ b/expected/truncate.out
@@ -155,6 +155,27 @@ SELECT * from cstore_truncate_test;
 ---+---
 (0 rows)
 
+-- test if a cached truncate from a pl/pgsql function works
+CREATE FUNCTION cstore_truncate_test_regular_func() RETURNS void AS $$
+BEGIN
+	INSERT INTO cstore_truncate_test_regular select a, a from generate_series(1, 10) a;
+	TRUNCATE TABLE cstore_truncate_test_regular;
+END;$$
+LANGUAGE plpgsql;
+SELECT cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
+
+-- the cached plans are used stating from the second call
+SELECT cstore_truncate_test_regular_func();
+ cstore_truncate_test_regular_func 
+-----------------------------------
+ 
+(1 row)
+
+DROP FUNCTION cstore_truncate_test_regular_func();
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;

--- a/sql/truncate.sql
+++ b/sql/truncate.sql
@@ -66,6 +66,19 @@ SELECT * from cstore_truncate_test_regular;
 TRUNCATE TABLE cstore_truncate_test;
 SELECT * from cstore_truncate_test;
 
+-- test if a cached truncate from a pl/pgsql function works
+CREATE FUNCTION cstore_truncate_test_regular_func() RETURNS void AS $$
+BEGIN
+	INSERT INTO cstore_truncate_test_regular select a, a from generate_series(1, 10) a;
+	TRUNCATE TABLE cstore_truncate_test_regular;
+END;$$
+LANGUAGE plpgsql;
+
+SELECT cstore_truncate_test_regular_func();
+-- the cached plans are used stating from the second call
+SELECT cstore_truncate_test_regular_func();
+DROP FUNCTION cstore_truncate_test_regular_func();
+
 DROP FOREIGN TABLE cstore_truncate_test, cstore_truncate_test_second;
 DROP TABLE cstore_truncate_test_regular;
 DROP FOREIGN TABLE cstore_truncate_test_compressed;


### PR DESCRIPTION
Hello,

CStoreProcessUtility() removes its relations from the list of relations of
truncate statements before passing it to standard_ProcessUtility(). When
the truncate is run from a pl/pgsql function, its plan can be cached.
Since the filtered list of relations created by CStoreProcessUtility() is
freed after the execution of the truncate, it corrupts the cached plan.
To avoid this, just restore the list of relations of the node when done.

The testcase from #132 created by @emiel (https://gist.github.com/emiel/4d4fd8c5c5ba9173e3175a08bb055be4) reproduces the problem. The problem disappears with this fix, but I don't know if it is enough to close the whole issue.

Best regards,