### PR TITLE
Fix issue 75. 

### DIFF
--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -748,7 +748,7 @@ SelectedBlockMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 	ListCell *columnCell = NULL;
 	uint32 blockIndex = 0;
 	List *restrictInfoList = BuildRestrictInfoList(whereClauseList);
-	#if PG_VERSION_NUM >=90400
+	#if PG_VERSION_NUM > 90500
 	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,0);
 	#else
 	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,PVC_REJECT_AGGREGATES,PVC_REJECT_PLACEHOLDERS);

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -748,7 +748,11 @@ SelectedBlockMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 	ListCell *columnCell = NULL;
 	uint32 blockIndex = 0;
 	List *restrictInfoList = BuildRestrictInfoList(whereClauseList);
+	#if PG_VERSION_NUM >=90400
 	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,0);
+	#else
+	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,PVC_REJECT_AGGREGATES,PVC_REJECT_PLACEHOLDERS);
+	#endif
 	selectedBlockMask = palloc0(stripeSkipList->blockCount * sizeof(bool));
 	memset(selectedBlockMask, true, stripeSkipList->blockCount * sizeof(bool));
 

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -748,7 +748,7 @@ SelectedBlockMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 	ListCell *columnCell = NULL;
 	uint32 blockIndex = 0;
 	List *restrictInfoList = BuildRestrictInfoList(whereClauseList);
-	#if PG_VERSION_NUM > 90500
+	#if PG_VERSION_NUM >= 90600
 	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,0);
 	#else
 	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,PVC_REJECT_AGGREGATES,PVC_REJECT_PLACEHOLDERS);

--- a/cstore_reader.c
+++ b/cstore_reader.c
@@ -748,11 +748,11 @@ SelectedBlockMask(StripeSkipList *stripeSkipList, List *projectedColumnList,
 	ListCell *columnCell = NULL;
 	uint32 blockIndex = 0;
 	List *restrictInfoList = BuildRestrictInfoList(whereClauseList);
-
+	List *whereClauseVars = pull_var_clause((Node *)whereClauseList,0);
 	selectedBlockMask = palloc0(stripeSkipList->blockCount * sizeof(bool));
 	memset(selectedBlockMask, true, stripeSkipList->blockCount * sizeof(bool));
 
-	foreach(columnCell, projectedColumnList)
+	foreach(columnCell, whereClauseVars)
 	{
 		Var *column = lfirst(columnCell);
 		uint32 columnIndex = column->varattno - 1;


### PR DESCRIPTION
Loop across whereclause for block skipping rather than projected columnlist.
Blockskipping is to be done for the whereclause and not for the projected column list.