### PR TITLE
Fix `cstore_fdw` dependency instructions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ before_install:
   - nuke_pg
 install:
   - sudo apt-get install protobuf-c-compiler
-  - sudo apt-get install libprotobuf-c0-dev
   - sudo locale-gen da_DK
   - sudo locale-gen da_DK.utf8
   - sudo pip install cpp-coveralls

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ So we need to install these packages first:
 
     # Ubuntu 10.4+
     sudo apt-get install protobuf-c-compiler
-    sudo apt-get install libprotobuf-c0-dev
 
     # Mac OS X
     brew install protobuf-c


### PR DESCRIPTION
`libprotobuf-c0-dev` and `protobuf-c-compiler` conflict: 

    user@machine:~$ sudo apt-get install libprotobuf-c0-dev
    Reading package lists... Done
    Building dependency tree       
    Reading state information... Done
    The following packages were automatically installed and are no longer required:

    libprotobuf-c1 libprotobuf9v5 libprotoc9v5

    Use 'sudo apt autoremove' to remove them.
    The following packages will be REMOVED:

    libprotobuf-c-dev protobuf-c-compiler

    ..........


    user@machine:~$ sudo apt-get install protobuf-c-compiler
    Reading package lists... Done
    Building dependency tree       
    Reading state information... Done
    The following package was automatically installed and is no longer required:

    libprotobuf-c0

    Use 'sudo apt autoremove' to remove it.
    The following additional packages will be installed:

    libprotobuf-c-dev

    The following packages will be REMOVED:

    libprotobuf-c0-dev

    The following NEW packages will be installed:

    libprotobuf-c-dev protobuf-c-compiler

Only `protobuf-c-compiler` is required.