### PR TITLE
Adapt installation instructions for Ubuntu 18.4+

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,11 @@ So we need to install these packages first:
 
     # Ubuntu 10.4+
     sudo apt-get install protobuf-c-compiler
+    sudo apt-get install libprotobuf-c0-dev
+    
+    # Ubuntu 18.4+
+    sudo apt-get install protobuf-c-compiler
+    sudo apt-get install libprotobuf-c-dev
 
     # Mac OS X
     brew install protobuf-c


### PR DESCRIPTION
The installation prerequisites in README.md don't work anymore on Ubunutu 18.04 because the package `libprotobuf-c0-dev` seems to have disappeared. However, there is a package called `libprotobuf-c-dev`, and the installation works with it. 

This PR adapts README.md accordingly