### PR TITLE
Mark foreign scan as parallel safe

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -143,6 +143,10 @@ static TupleTableSlot * CStoreExecForeignInsert(EState *executorState,
 												TupleTableSlot *planSlot);
 static void CStoreEndForeignModify(EState *executorState, ResultRelInfo *relationInfo);
 static void CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo);
+#if PG_VERSION_NUM >= 90600
+static bool CStoreIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel,
+											RangeTblEntry *rte);
+#endif
 
 
 /* declarations for dynamic loading */
@@ -1212,6 +1216,10 @@ cstore_fdw_handler(PG_FUNCTION_ARGS)
 #if PG_VERSION_NUM >= 110000
 	fdwRoutine->BeginForeignInsert = CStoreBeginForeignInsert;
 	fdwRoutine->EndForeignInsert = CStoreEndForeignInsert;
+#endif
+
+#if PG_VERSION_NUM >= 90600
+	fdwRoutine->IsForeignScanParallelSafe = CStoreIsForeignScanParallelSafe;
 #endif
 
 	PG_RETURN_POINTER(fdwRoutine);
@@ -2336,3 +2344,23 @@ CStoreEndForeignInsert(EState *executorState, ResultRelInfo *relationInfo)
 		heap_close(relation, ShareUpdateExclusiveLock);
 	}
 }
+
+
+#if PG_VERSION_NUM >= 90600
+/*
+ * CStoreIsForeignScanParallelSafe always returns true to indicate that
+ * reading from a cstore_fdw table in a parallel worker is safe. This
+ * does not enable parallelism for queries on individual cstore_fdw
+ * tables, but does allow parallel scans of cstore_fdw partitions.
+ *
+ * cstore_fdw is parallel-safe because all writes are immediately committed
+ * to disk and then read from disk. There is no uncommitted state that needs
+ * to be shared across processes.
+ */
+static bool
+CStoreIsForeignScanParallelSafe(PlannerInfo *root, RelOptInfo *rel,
+								RangeTblEntry *rte)
+{
+	return true;
+}
+#endif


### PR DESCRIPTION
Fixes #178 

There's no reason why parallel scans of a cstore_fdw table would not be safe right now. Multiple processes can read from tables in parallel and there is no state kept between individual statements, which means that another process (like a parallel worker) can read everything that was written. 

Partially addresses #161 

Based it against master because develop does not have PG11 support