### PR TITLE
README.md improved

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Then, let's log into Postgres, and run the following commands to create a column
 store foreign table:
 
 ```SQL
--- load extension first time after install
+-- load extension first time after install (make sure that this command is being executed in schema "public"):
 CREATE EXTENSION cstore_fdw;
 
 -- create server object


### PR DESCRIPTION
In case if non-default schema is used while creating extension, functions will be created in current schema instead of `public`. But `cstore_clean_table_resources` function is explicitly called from `public` schema, so the user will get an error `ERROR: function cstore_clean_table_resources(oid) does not exist` (similar to https://github.com/citusdata/cstore_fdw/issues/125 bug).

We need to make sure that everything is created in `public` schema.