### PR TITLE
update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ installation's bin/ directory path. For example:
     PATH=/usr/local/pgsql/bin/:$PATH make
     sudo PATH=/usr/local/pgsql/bin/:$PATH make install
 
-**Note.** cstore_fdw requires PostgreSQL 9.3, 9.4, 9.5, 9.6 or 10. It doesn't
+**Note.** cstore_fdw requires PostgreSQL version from 9.3 to 12. It doesn't
 support earlier versions of PostgreSQL.
 
 
@@ -177,8 +177,8 @@ OPTIONS(compression 'pglz');
 Next, we load data into the table:
 
 ```SQL
-COPY customer_reviews FROM '/home/user/customer_reviews_1998.csv' WITH CSV;
-COPY customer_reviews FROM '/home/user/customer_reviews_1999.csv' WITH CSV;
+\COPY customer_reviews FROM 'customer_reviews_1998.csv' WITH CSV;
+\COPY customer_reviews FROM 'customer_reviews_1999.csv' WITH CSV;
 ```
 
 **Note.** If you are getting ```ERROR: cannot copy to foreign table
@@ -234,7 +234,7 @@ hosts.  You can easily install and run other PostgreSQL extensions and foreign d
 wrappers—including cstore_fdw—alongside Citus.
 
 You can create a cstore_fdw table and distribute it using the
-```master_create_distributed_table()``` UDF just like any other table. You can load data
+```create_distributed_table()``` UDF just like any other table. You can load data
 using the ```copy``` command as you would do in single node PostgreSQL.
 
 Using Skip Indexes


### PR DESCRIPTION
This pr aims to:
 * Replace `master_create_distributed_table` with `create_distributed_table` in `README.md` as `master_create_distributed_table` is [deprecated](http://docs.citusdata.com/en/v9.1/develop/api_udf.html#master-create-distributed-table) in Citus.
 * Make paths used to download sample data convenient.