### PR TITLE
Fix count(t.*) type queries after column drop

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1878,6 +1878,12 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 	{
 		ListCell *neededColumnCell = NULL;
 		Var *column = NULL;
+		Form_pg_attribute attributeForm =  TupleDescAttr(tupleDescriptor, columnIndex - 1);
+
+		if (attributeForm->attisdropped)
+		{
+			continue;
+		}
 
 		/* look for this column in the needed column list */
 		foreach(neededColumnCell, neededColumnList)
@@ -1890,7 +1896,6 @@ ColumnList(RelOptInfo *baserel, Oid foreignTableId)
 			}
 			else if (neededColumn->varattno == wholeRow)
 			{
-				Form_pg_attribute attributeForm =  TupleDescAttr(tupleDescriptor, columnIndex - 1);
 				Index tableId = neededColumn->varno;
 
 				column = makeVar(tableId, columnIndex, attributeForm->atttypid,

--- a/expected/alter.out
+++ b/expected/alter.out
@@ -127,6 +127,18 @@ SELECT * from test_alter_table;
  1 | 4 | ABCDEF
 (7 rows)
 
+SELECT count(*) from test_alter_table;
+ count 
+-------
+     7
+(1 row)
+
+SELECT count(t.*) from test_alter_table t;
+ count 
+-------
+     7
+(1 row)
+
 -- unsupported default values
 ALTER FOREIGN TABLE test_alter_table ADD COLUMN g boolean DEFAULT isfinite(current_date);
 ALTER FOREIGN TABLE test_alter_table ADD COLUMN h DATE DEFAULT current_date;

--- a/sql/alter.sql
+++ b/sql/alter.sql
@@ -53,6 +53,8 @@ ALTER FOREIGN TABLE test_alter_table DROP COLUMN c;
 ALTER FOREIGN TABLE test_alter_table DROP COLUMN e;
 ANALYZE test_alter_table;
 SELECT * from test_alter_table;
+SELECT count(*) from test_alter_table;
+SELECT count(t.*) from test_alter_table t;
 
 
 -- unsupported default values


### PR DESCRIPTION
We are failing to eliminate dropped column when we are enumerating columns to project.
Thus queries like `select count(t.*) from table t` or `select t from table t` were failing.

Fixes : #217 