### PR TITLE
docs: fix simple typo, supress -> suppress

### DIFF
--- a/cstore_fdw.c
+++ b/cstore_fdw.c
@@ -1926,7 +1926,7 @@ CStoreExplainForeignScan(ForeignScanState *scanState, ExplainState *explainState
 
 	ExplainPropertyText("CStore File", cstoreFdwOptions->filename, explainState);
 
-	/* supress file size if we're not showing cost details */
+	/* suppress file size if we're not showing cost details */
 	if (explainState->costs)
 	{
 		struct stat statBuffer;


### PR DESCRIPTION
There is a small typo in cstore_fdw.c.

Should read `suppress` rather than `supress`.

